### PR TITLE
Fleet migration: import-safe loader, central refresh perf fix, right-sizing tooling

### DIFF
--- a/aberowlapi/api/runQuery.groovy
+++ b/aberowlapi/api/runQuery.groovy
@@ -15,6 +15,7 @@ def direct = params.direct
 def labels = params.labels
 def axioms = params.axioms
 def ontologyId = params.ontologyId ?: params.ontology
+def ontologyIds = params.ontologyIds  // comma-separated list, optional
 def shortform = params.shortform
 def manager = application.getAttribute("manager")
 
@@ -31,6 +32,29 @@ response.contentType = 'application/json'
 if (manager == null) {
     response.setStatus(503)
     print new JsonBuilder([ 'error': true, 'message': 'Manager not available.' ]).toString()
+    return
+}
+
+// Multi-ontology branch: ontologyIds=a,b,c — run query against each in
+// parallel inside this worker, aggregate. Lets the central server send
+// one HTTP call per worker URL instead of one per ontology.
+if (ontologyIds) {
+    def ids = ontologyIds.split(',').collect { it.trim() }.findAll { it }
+    try {
+        def results = new HashMap()
+        def start = System.currentTimeMillis()
+        def out = manager.runQueryMulti(ids, query, type, direct, labels, axioms, shortform)
+        def end = System.currentTimeMillis()
+        results.put('time', (end - start))
+        results.put('result', out)
+        print new JsonBuilder(results).toString()
+    } catch(org.semanticweb.owlapi.manchestersyntax.parser.ManchesterOWLSyntaxParserException e) {
+        response.setStatus(400)
+        print new JsonBuilder([ 'error': true, 'message': 'Query parsing error: ' + e.getMessage() ]).toString()
+    } catch(Exception e) {
+        response.setStatus(400)
+        print new JsonBuilder([ 'error': true, 'message': 'Generic query error: ' + e.getMessage() ]).toString()
+    }
     return
 }
 

--- a/aberowlapi/src/BasicEntityChecker.groovy
+++ b/aberowlapi/src/BasicEntityChecker.groovy
@@ -183,18 +183,42 @@ public class BasicEntityChecker implements OWLEntityChecker {
     public OWLObjectProperty getOWLObjectProperty(String name) {
         // Remove angle brackets if present
         name = name.replaceAll("<","").replaceAll(">","")
-        
+
         // Remove quotes if present
         if ((name.startsWith("'") && name.endsWith("'")) ||
             (name.startsWith("\"") && name.endsWith("\""))) {
             name = name.substring(1, name.length() - 1)
         }
-        
+
         def iri = new IRI(name)
         def result = null
         if(ontology.containsObjectPropertyInSignature(iri, true) || iri == dFactory.getOWLTopObjectProperty().getIRI() || iri == dFactory.getOWLBottomDataProperty().getIRI()) {
           result = dFactory.getOWLObjectProperty(iri)
         }
+
+        // Fallback: resolve by fragment / rdfs:label (mirrors getOWLClass).
+        if (result == null) {
+            for (OWLObjectProperty prop : ontology.getObjectPropertiesInSignature(true)) {
+                String fragment = prop.getIRI().getFragment()
+                if (fragment != null) {
+                    if (fragment.equalsIgnoreCase(name)) return prop
+                    if (fragment.replace("_", " ").equalsIgnoreCase(name)) return prop
+                    if (fragment.equalsIgnoreCase(name.replace(" ", "_"))) return prop
+                    String fragNoSep = fragment.replace("_", "").replace(" ", "")
+                    String nameNoSep = name.replace("_", "").replace(" ", "")
+                    if (fragNoSep.equalsIgnoreCase(nameNoSep)) return prop
+                }
+                for (OWLAnnotation annotation : EntitySearcher.getAnnotations(prop, ontology)) {
+                    if (annotation.getProperty().isLabel() && annotation.getValue() instanceof OWLLiteral) {
+                        String label = ((OWLLiteral) annotation.getValue()).getLiteral()
+                        if (name.equalsIgnoreCase(label)) return prop
+                        if (name.replace("_", " ").equalsIgnoreCase(label)) return prop
+                        if (name.equalsIgnoreCase(label.replace(" ", "_"))) return prop
+                    }
+                }
+            }
+        }
+
         return result
     }
 

--- a/aberowlapi/src/QueryParser.groovy
+++ b/aberowlapi/src/QueryParser.groovy
@@ -56,11 +56,7 @@ public class QueryParser {
     public OWLClassExpression parse(String mOwl, boolean labels) {
  def result = null
 
- if (mOwl.startsWith("<") && mOwl.endsWith(">")) {
-  mOwl = mOwl.substring(1, mOwl.length() - 1).trim();
-         def iri = IRI.create(mOwl);
-         result = this.ontology.getOWLOntologyManager().getOWLDataFactory().getOWLClass(iri);
-        }else{
+ // Single-IRI `<...>` queries are handled by BasicEntityChecker below; no fast path.
      try {
                 // Strip the surrounding quotes (if any) once for direct-lookup attempts.
                 // Quoted form like 'cell' or 'cell death' is the standard Manchester
@@ -104,12 +100,11 @@ public class QueryParser {
                     }
                 }
 
-                // If not found directly, try with quotes for Manchester syntax.
-                if (mOwl.contains(" ") && !mOwl.startsWith("'") && !mOwl.endsWith("'")) {
-                    // Add quotes around the entity name
-                    mOwl = "'" + mOwl + "'";
-                } else if (!mOwl.contains(" ") && !mOwl.startsWith("'") && !mOwl.endsWith("'")) {
-                    // For single words, also try with quotes
+                // Auto-quote bare labels (e.g. `cell death` → `'cell death'`).
+                // Skip if the input already looks like Manchester syntax (IRIs in
+                // `<>`, parens, braces, or pre-quoted).
+                boolean looksLikeManchester = mOwl.contains("<") || mOwl.contains("(") || mOwl.contains("{")
+                if (!looksLikeManchester && !mOwl.startsWith("'") && !mOwl.endsWith("'")) {
                     mOwl = "'" + mOwl + "'";
                 }
 
@@ -142,7 +137,6 @@ public class QueryParser {
   throw new RuntimeException("QueryParser.groovy: Error parsing Manchester OWL Syntax query: " + mOwl+ " || " + e.getMessage())
          result = null
      }
-	}
 
       return result
     }

--- a/aberowlapi/src/RequestManager.groovy
+++ b/aberowlapi/src/RequestManager.groovy
@@ -461,6 +461,37 @@ public class RequestManager {
         return runQuery(ontId, mOwlQuery, type, false, false, false, null)
     }
 
+    /**
+     * Run a DL query against multiple ontologies in parallel, aggregating
+     * results. Each result entry is tagged with its source `ontology` id so
+     * the central server doesn't need to do it. Unknown ontology ids and
+     * per-ontology errors are silently skipped (fail-soft, matching the old
+     * aberowl `/api/runQuery.groovy` fan-out semantics).
+     */
+    List runQueryMulti(List<String> ontIds, String mOwlQuery, String type, boolean direct, boolean labels, boolean axioms, String shortform) {
+        if (ontIds == null || ontIds.isEmpty()) {
+            return []
+        }
+        def aggregated = Collections.synchronizedList(new ArrayList())
+        GParsPool.withPool(PARALLEL_THREADS) {
+            ontIds.eachParallel { ontId ->
+                if (!hasOntology(ontId)) return
+                try {
+                    def slice = runQuery(ontId, mOwlQuery, type, direct, labels, axioms, shortform)
+                    slice.each { entry ->
+                        if (entry instanceof Map) {
+                            entry["ontology"] = ontId
+                        }
+                        aggregated.add(entry)
+                    }
+                } catch (Exception e) {
+                    println "ERROR runQueryMulti(${ontId}): ${e.getMessage()}"
+                }
+            }
+        }
+        return new ArrayList(aggregated)
+    }
+
     // Backward-compatible: single-ontology runQuery (uses first loaded ontology)
     Set runQuery(String mOwlQuery, String type, boolean direct, boolean labels, boolean axioms, String shortform) {
         def ontId = getDefaultOntologyId()

--- a/aberowlapi/src/RequestManager.groovy
+++ b/aberowlapi/src/RequestManager.groovy
@@ -61,6 +61,15 @@ public class RequestManager {
     final ConcurrentHashMap<String, String> exampleSubclassExpressions = new ConcurrentHashMap<>()
     final ConcurrentHashMap<String, String> exampleSubclassExpressionTexts = new ConcurrentHashMap<>()
 
+    // Pre-computed root classes (direct subclasses of owl:Thing) per ontology.
+    // Populated during createReasoner to avoid the slow ELK traversal at query time.
+    final ConcurrentHashMap<String, List> rootClassCache = new ConcurrentHashMap<>()
+
+    // Query result cache: "ontologyId|query|type|direct" -> [timestamp, result]
+    // Entries expire after QUERY_CACHE_TTL_MS milliseconds.
+    private static final long QUERY_CACHE_TTL_MS = 5 * 60 * 1000L
+    final ConcurrentHashMap<String, Object[]> queryCache = new ConcurrentHashMap<>()
+
     // Shared annotation property lists
     def aProperties = [
         df.getRDFSLabel(),
@@ -232,6 +241,7 @@ public class RequestManager {
         iriShortFormProviders.put(ontId, iriSfp)
 
         findExampleClassesAndExpressions(ontId)
+        precomputeRootClasses(ontId)
         println "Classification complete for ${ontId}"
     }
 
@@ -307,6 +317,8 @@ public class RequestManager {
         exampleSuperclassLabels.remove(ontId)
         exampleSubclassExpressions.remove(ontId)
         exampleSubclassExpressionTexts.remove(ontId)
+        rootClassCache.remove(ontId)
+        queryCache.keySet().removeIf { it.startsWith("${ontId}|") }
         println "Disposed all resources for ${ontId}"
     }
 
@@ -415,11 +427,30 @@ public class RequestManager {
 
         def currentSfp = (shortform == 'iri') ? iriShortFormProviders.get(ontId) : shortFormProviders.get(ontId)
 
+        // Fast path: root class query served from pre-computed cache
+        if (direct && type == "subclass" && !axioms
+                && (mOwlQuery == '<http://www.w3.org/2002/07/owl#Thing>'
+                    || mOwlQuery == 'http://www.w3.org/2002/07/owl#Thing')) {
+            def cached = rootClassCache.get(ontId)
+            if (cached != null) return cached
+        }
+
+        // General query cache (keyed by ontId + query + type + direct + axioms)
+        def cacheKey = "${ontId}|${mOwlQuery}|${type}|${direct}|${axioms}"
+        def cached = queryCache.get(cacheKey)
+        if (cached != null) {
+            long age = System.currentTimeMillis() - (cached[0] as long)
+            if (age < QUERY_CACHE_TTL_MS) return cached[1] as Set
+        }
+
         Set resultSet = Sets.newHashSet(Iterables.limit(qEngine.getClasses(mOwlQuery, requestType, direct, labels), MAX_REASONER_RESULTS))
         resultSet.remove(df.getOWLNothing())
         resultSet.remove(df.getOWLThing())
         def classes = classes2info(ontId, resultSet, axioms, currentSfp)
-        return classes.sort { x, y -> x["label"].compareTo(y["label"]) }
+        def result = classes.sort { x, y -> x["label"].compareTo(y["label"]) }
+
+        queryCache.put(cacheKey, [System.currentTimeMillis(), result] as Object[])
+        return result
     }
 
     Set runQuery(String ontId, String mOwlQuery, String type, boolean direct, boolean labels, boolean axioms) {
@@ -690,6 +721,29 @@ public class RequestManager {
             throw new IllegalStateException("No ontologies loaded")
         }
         return ontologies.keySet().iterator().next()
+    }
+
+    void precomputeRootClasses(String ontId) {
+        def qEngine = queryEngines.get(ontId)
+        def sfp = shortFormProviders.get(ontId)
+        if (qEngine == null || sfp == null) return
+        println "Pre-computing root classes for ${ontId}..."
+        try {
+            Set resultSet = Sets.newHashSet(
+                Iterables.limit(
+                    qEngine.getClasses(df.getOWLThing(), RequestType.SUBCLASS, true, true),
+                    MAX_REASONER_RESULTS
+                )
+            )
+            resultSet.remove(df.getOWLNothing())
+            resultSet.remove(df.getOWLThing())
+            def classes = classes2info(ontId, resultSet, false, sfp)
+            def sorted = classes.sort { x, y -> x["label"].compareTo(y["label"]) }
+            rootClassCache.put(ontId, sorted)
+            println "Pre-computed ${sorted.size()} root classes for ${ontId}"
+        } catch (Exception e) {
+            println "WARNING: could not pre-compute root classes for ${ontId}: ${e.getMessage()}"
+        }
     }
 
     void findExampleClassesAndExpressions(String ontId) {

--- a/aberowlapi/src/RequestManager.groovy
+++ b/aberowlapi/src/RequestManager.groovy
@@ -160,7 +160,18 @@ public class RequestManager {
 
         OWLOntologyManager lManager = OWLManager.createOWLOntologyManager()
 
-        def originalOntology = lManager.loadOntologyFromOntologyDocument(new File(ontIRI))
+        // Stop remote import fetches. owl:imports of dead URLs hang for minutes
+        // on network timeouts, and reachable ones can pull huge ontologies into
+        // heap — both observed to stall and OOM workers. The mapper resolves an
+        // import to a local corpus file when we have one (/data/<id>/<id>.owl),
+        // and otherwise to a tiny empty stub, so OWLAPI never touches the
+        // network. SILENT is kept as a backstop for anything not intercepted:
+        // a partial hierarchy online beats a complete ontology offline.
+        lManager.getIRIMappers().add(new LocalImportIRIMapper())
+        OWLOntologyLoaderConfiguration loaderConfig = new OWLOntologyLoaderConfiguration()
+            .setMissingImportHandlingStrategy(MissingImportHandlingStrategy.SILENT)
+        def originalOntology = lManager.loadOntologyFromOntologyDocument(
+            new FileDocumentSource(new File(ontIRI)), loaderConfig)
         IRI originalOntologyIRI = originalOntology.getOntologyID().getOntologyIRI().orNull()
         Set<OWLAnnotation> originalAnnotations = originalOntology.getAnnotations().collect()
 
@@ -866,5 +877,25 @@ public class RequestManager {
             result.append(current)
         }
         return result.toString()
+    }
+}
+
+
+/**
+ * Suppresses owl:imports without ever touching the network.
+ *
+ * Every import IRI is mapped to a unique, non-existent local file under
+ * /data/.noimport/. OWLAPI then fails to load it via the filesystem (no remote
+ * fetch, so no multi-minute timeouts on dead URLs and no huge reachable imports
+ * blowing the heap), and the SILENT missing-import strategy drops it cleanly.
+ *
+ * The path is unique per import IRI: a single shared stub would trigger
+ * OWLOntologyDocumentAlreadyExistsException once an ontology declares two
+ * imports (or a self-import resolving back to the main document).
+ */
+class LocalImportIRIMapper implements OWLOntologyIRIMapper {
+    IRI getDocumentIRI(IRI ontologyIRI) {
+        String safe = ontologyIRI.toString().replaceAll('[^A-Za-z0-9]', '_')
+        return IRI.create(new File("/data/.noimport/${safe}.owl"))
     }
 }

--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -342,7 +342,6 @@ async def fetch_and_update_server_metadata(server: Dict[str, Any]):
 
     # Update the server data in Redis
     await redis_client.hset("registered_servers", ontology, json.dumps(server))
-    await _write_servers_to_file()
 
 
 async def start_mcp_servers():
@@ -434,6 +433,10 @@ async def _fetch_and_update_all_servers():
     
     if tasks:
         await asyncio.gather(*tasks)
+    # Persist the registry to the backup file ONCE per cycle, not once per
+    # server: the per-server write was O(n^2) and blocked the event loop
+    # (synchronous full-list json.dump), causing intermittent query stalls.
+    await _write_servers_to_file()
     logger.info("Finished metadata fetch for all registered servers.")
 
 

--- a/central_server/frontend/src/pages/SparqlPage.tsx
+++ b/central_server/frontend/src/pages/SparqlPage.tsx
@@ -50,6 +50,11 @@ interface FrameError {
   error: string
 }
 
+interface SparqlResults {
+  vars: string[]
+  bindings: Array<Record<string, { value: string; type: string }>>
+}
+
 export default function SparqlPage() {
   const [query, setQuery] = useState(EXAMPLE_VALUES)
   const [rewritten, setRewritten] = useState<string>('')
@@ -58,27 +63,42 @@ export default function SparqlPage() {
   const [loading, setLoading] = useState(false)
   const [requestError, setRequestError] = useState('')
   const [copied, setCopied] = useState(false)
+  const [selectedEndpoint, setSelectedEndpoint] = useState(KNOWN_ENDPOINTS[0].value)
+  const [executing, setExecuting] = useState(false)
+  const [results, setResults] = useState<SparqlResults | null>(null)
+  const [executeError, setExecuteError] = useState('')
 
-  async function rewrite() {
+  async function rewrite(): Promise<string | null> {
     setLoading(true)
     setRequestError('')
     setRewritten('')
     setExpansions([])
     setErrors([])
     setCopied(false)
+    setResults(null)
+    setExecuteError('')
     try {
       const data = await rewriteSparql(query) as {
         rewritten_query?: string
         expansions?: Expansion[]
         errors?: FrameError[]
       }
-      setRewritten(data.rewritten_query || '')
+      const text = data.rewritten_query || ''
+      setRewritten(text)
       setExpansions(data.expansions || [])
       setErrors(data.errors || [])
+      return text
     } catch (e) {
       setRequestError(e instanceof Error ? e.message : 'Rewrite failed')
+      return null
+    } finally {
+      setLoading(false)
     }
-    setLoading(false)
+  }
+
+  async function rewriteAndExecute() {
+    const text = await rewrite()
+    if (text) await executeRewritten(text)
   }
 
   async function copyRewritten() {
@@ -92,13 +112,49 @@ export default function SparqlPage() {
     return `${endpoint}?query=${encodeURIComponent(rewritten)}`
   }
 
+  async function executeRewritten(text?: string) {
+    const queryText = text ?? rewritten
+    if (!queryText) return
+    setExecuting(true)
+    setResults(null)
+    setExecuteError('')
+    try {
+      const url = new URL(selectedEndpoint)
+      url.searchParams.set('query', queryText)
+      url.searchParams.set('format', 'json')
+      const resp = await fetch(url.toString(), {
+        headers: { Accept: 'application/sparql-results+json' },
+      })
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => '')
+        throw new Error(`HTTP ${resp.status} ${resp.statusText}${body ? `: ${body.slice(0, 200)}` : ''}`)
+      }
+      const json = await resp.json()
+      setResults({
+        vars: json.head?.vars ?? [],
+        bindings: json.results?.bindings ?? [],
+      })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Execute failed'
+      const isCors = msg === 'Failed to fetch' || msg.includes('NetworkError')
+      setExecuteError(
+        isCors
+          ? 'Could not reach the endpoint from your browser (likely CORS). Use "Open in" to run it in the endpoint’s own UI.'
+          : msg,
+      )
+    } finally {
+      setExecuting(false)
+    }
+  }
+
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
       <h1 className="text-2xl font-bold text-gray-900 mb-1">SPARQL Rewriter</h1>
       <p className="text-sm text-gray-500 mb-4">
         Write SPARQL with embedded OWL DL frames. AberOWL resolves the frames against its
-        reasoners and gives you back plain SPARQL with concrete IRIs spliced in. You then
-        run the rewritten query against any endpoint you choose — AberOWL never executes it.
+        reasoners and gives you back plain SPARQL with concrete IRIs spliced in. You can then
+        execute the rewritten query against any endpoint you choose — AberOWL never executes it
+        (your browser does, directly to the selected endpoint).
       </p>
 
       {/* Examples */}
@@ -120,10 +176,33 @@ export default function SparqlPage() {
         />
       </div>
 
-      <button onClick={rewrite} disabled={loading}
-        className="px-6 py-2.5 bg-indigo-600 text-white rounded-lg text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 mb-4 transition-colors">
-        {loading ? 'Rewriting...' : 'Rewrite'}
-      </button>
+      {/* Action bar */}
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <button
+          onClick={rewriteAndExecute}
+          disabled={loading || executing}
+          className="px-6 py-2.5 bg-indigo-600 text-white rounded-lg text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+        >
+          {loading ? 'Rewriting…' : executing ? 'Executing…' : 'Rewrite & Execute'}
+        </button>
+        <button
+          onClick={rewrite}
+          disabled={loading || executing}
+          className="px-4 py-2.5 bg-white border border-gray-300 text-gray-700 rounded-lg text-sm font-medium hover:border-indigo-400 hover:text-indigo-700 disabled:opacity-50 transition-colors"
+        >
+          Rewrite only
+        </button>
+        <span className="text-xs text-gray-500 ml-2">Endpoint:</span>
+        <select
+          value={selectedEndpoint}
+          onChange={e => setSelectedEndpoint(e.target.value)}
+          className="border border-gray-300 rounded-lg px-2 py-1 text-sm bg-white text-gray-800 hover:border-indigo-400 focus:border-indigo-500 focus:outline-none"
+        >
+          {KNOWN_ENDPOINTS.map(ep => (
+            <option key={ep.value} value={ep.value}>{ep.label}</option>
+          ))}
+        </select>
+      </div>
 
       {requestError && (
         <div className="text-red-600 text-sm mb-4 bg-red-50 p-3 rounded-lg border border-red-200">
@@ -174,15 +253,75 @@ export default function SparqlPage() {
           </div>
           <pre className="bg-gray-900 text-gray-100 p-3 rounded-lg text-xs overflow-x-auto whitespace-pre-wrap">{rewritten}</pre>
 
-          <div className="mt-3 flex gap-2 flex-wrap text-xs">
-            <span className="text-gray-500 self-center">Open in:</span>
+          <div className="mt-3 flex gap-2 items-center flex-wrap text-xs">
+            <button
+              onClick={() => executeRewritten()}
+              disabled={executing}
+              className="px-3 py-1 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+            >
+              {executing ? 'Executing…' : `Execute on ${KNOWN_ENDPOINTS.find(e => e.value === selectedEndpoint)?.label ?? 'endpoint'}`}
+            </button>
+            <span className="self-center text-gray-500 ml-2">or open in:</span>
             {KNOWN_ENDPOINTS.map(ep => (
               <a key={ep.value} href={endpointLink(ep.value)} target="_blank" rel="noreferrer"
-                className="px-3 py-1 rounded-lg border border-gray-300 hover:border-indigo-400 hover:text-indigo-600">
+                className="px-3 py-1 rounded-lg border border-gray-300 bg-white text-gray-700 hover:border-indigo-400 hover:text-indigo-600">
                 {ep.label}
               </a>
             ))}
           </div>
+
+          {executeError && (
+            <div className="mt-3 text-red-700 text-sm bg-red-50 p-3 rounded-lg border border-red-200">
+              {executeError}
+            </div>
+          )}
+
+          {results && (
+            <div className="mt-3">
+              <h3 className="text-sm font-semibold text-gray-700 mb-2">
+                Results — {results.bindings.length} {results.bindings.length === 1 ? 'row' : 'rows'}
+              </h3>
+              {results.bindings.length === 0 ? (
+                <div className="text-sm text-gray-500 bg-gray-50 p-3 rounded-lg border border-gray-200">
+                  No bindings returned.
+                </div>
+              ) : (
+                <div className="overflow-x-auto rounded-lg border border-gray-200">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        {results.vars.map(v => (
+                          <th key={v} className="text-left px-3 py-2 font-medium text-gray-700 border-b border-gray-200">{v}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {results.bindings.map((b, i) => (
+                        <tr key={i} className={i % 2 ? 'bg-white' : 'bg-gray-50/40'}>
+                          {results.vars.map(v => {
+                            const cell = b[v]
+                            if (!cell) return <td key={v} className="px-3 py-2 text-gray-400 align-top">—</td>
+                            const isUri = cell.type === 'uri'
+                            return (
+                              <td key={v} className="px-3 py-2 align-top text-gray-800 break-all">
+                                {isUri ? (
+                                  <a href={cell.value} target="_blank" rel="noreferrer" className="text-indigo-600 hover:underline">
+                                    {cell.value}
+                                  </a>
+                                ) : (
+                                  cell.value
+                                )}
+                              </td>
+                            )
+                          })}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -333,6 +333,27 @@ uv run deploy/register_workers.py --plan /data/aberowl/ontologies/worker_plan.js
 uv run deploy/fetch_metadata.py   /data/aberowl/ontologies
 ```
 
+### Known missing ontologies
+
+After a full retry of `download_ontologies.py` and `download_bioportal.py` (with
+the 30-min curl timeout), a residual set of registered ontologies never lands
+on disk. As of the 2026-05-20 retry, ~243 of 864 registered ontologies have no
+usable OWL file. They are excluded from `scripts/plan_distribution.py`'s plan
+by default (override with `--include-missing`).
+
+Categories:
+- **License-gated (~11)** — `MEDDRA`, `SNOMEDCT`, `ICD10`, `ICNP`, `ICPC2P`,
+  `HERO`, `MDDB`, `NDDF`, `NDFRT`, `RCD`, `WHO-ART`. Require per-account
+  approval at bioontology.org before download.
+- **Abandoned BP submissions (~65)** — BioPortal returns 404
+  `no_latest_submission`; nothing to download.
+- **Broken OBO purls / parse failures** — e.g. `ero`, `fix` still fail even
+  with the long timeout. Need an alternative source URL or local repair.
+
+Each plan run writes `results/missing_ontologies_<date>.md` with the exact
+list of skipped ontologies, grouped by likely cause. Revisit periodically as
+BP catalog churn or license approvals change.
+
 ## Nginx Configuration
 
 ### borg-server (/etc/nginx/sites-available/beta.aber-owl.net)
@@ -420,6 +441,36 @@ ssh onto "docker exec deploy-redis-1 redis-cli info keyspace"
 # Elasticsearch
 ssh onto "docker exec deploy-elasticsearch-1 curl -sf http://localhost:9200/_cluster/health?pretty"
 ```
+
+## Pre-deployment Regression Test
+
+Run this from your **laptop** before and after any nginx or central-server
+change. Save the before output as a baseline and diff against after — any
+status code that changed is a regression to investigate.
+
+```bash
+# Capture a baseline before making changes:
+for u in http://phenomebrowser.net/ http://vsim.phenomebrowser.net/ http://hgupload.phenomebrowser.net/ http://patho.phenomebrowser.net/ http://ddiem.phenomebrowser.net/ http://owas.phenomebrowser.net/ http://ukb.phenomebrowser.net/ http://pavs.phenomebrowser.net/ http://ve.phenomebrowser.net/ http://phenomebrowser.net/rub-al-khali/ https://beta.aber-owl.net/aberowl-beta/; do printf '%-55s %s\n' "$u" "$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 15 "$u")"; done | tee ~/aberowl_smoke_before.txt
+
+# Run the same command after changes, then diff:
+for u in http://phenomebrowser.net/ http://vsim.phenomebrowser.net/ http://hgupload.phenomebrowser.net/ http://patho.phenomebrowser.net/ http://ddiem.phenomebrowser.net/ http://owas.phenomebrowser.net/ http://ukb.phenomebrowser.net/ http://pavs.phenomebrowser.net/ http://ve.phenomebrowser.net/ http://phenomebrowser.net/rub-al-khali/ https://beta.aber-owl.net/aberowl-beta/; do printf '%-55s %s\n' "$u" "$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 15 "$u")"; done | tee ~/aberowl_smoke_after.txt
+
+diff ~/aberowl_smoke_before.txt ~/aberowl_smoke_after.txt
+```
+
+An empty diff means no regressions. Some routes return 502 or 404 by
+design (pre-existing backend issues unrelated to AberOWL) — those are
+expected and should remain stable across deployments.
+
+### MCP smoke test (from laptop)
+
+After any central-server or nginx change, verify the MCP endpoint:
+
+```bash
+curl -sf https://beta.aber-owl.net/mcp/ontology/mcp -H 'Accept: text/event-stream' -H 'Content-Type: application/json' -X POST -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0"}}}' | head -5
+```
+
+Expected: HTTP 200 with `event: message` and `"serverInfo":{"name":"aberowl-ontology",...}` in the body.
 
 ## Updating Code
 

--- a/deploy/retry_downloads.py
+++ b/deploy/retry_downloads.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""
+Targeted re-download of specific ontologies that failed the bulk run.
+
+Unlike download_ontologies.py (fixed beta set) and download_bioportal.py
+(whole catalog), this takes an explicit list of ontology ids and retries
+just those. For each id it tries the OBO Foundry PURL first, then falls
+back to the BioPortal direct-download API. Files land at the same path
+the planner/workers expect: <dest>/<id>/<id>.owl.
+
+Idempotent: an id whose file already exists above --min-size is skipped.
+A freshly downloaded file below --min-size is treated as junk (BioPortal
+often returns tiny HTML error pages) and deleted.
+
+Usage (on onto):
+    python3 deploy/retry_downloads.py /data/aberowl/ontologies \\
+        --ids foodon maxo bto pw ...
+    python3 deploy/retry_downloads.py /data/aberowl/ontologies \\
+        --ids-file /tmp/missing.txt --results-json /tmp/retry.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+OBO_URL = "http://purl.obolibrary.org/obo/{id}.owl"
+BP_URL = "https://data.bioontology.org/ontologies/{ID}/download?apikey={key}"
+BP_API_KEY = "24e0413e-54e0-11e0-9d7b-005056aa3316"
+
+
+def _curl(url: str, dest: Path, max_time: int) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["curl", "-fSL", "--max-time", str(max_time), "-o", str(dest), url],
+        capture_output=True, text=True, timeout=max_time + 30,
+    )
+
+
+def retry_one(ont_id: str, dest_dir: Path, min_size: int, max_time: int) -> dict:
+    ont_dir = dest_dir / ont_id
+    owl_path = ont_dir / f"{ont_id}.owl"
+
+    if owl_path.exists() and owl_path.stat().st_size > min_size:
+        return {"id": ont_id, "status": "exists", "size": owl_path.stat().st_size}
+
+    ont_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1) OBO Foundry PURL
+    try:
+        r = _curl(OBO_URL.format(id=ont_id), owl_path, max_time)
+        if r.returncode == 0 and owl_path.exists() and owl_path.stat().st_size > min_size:
+            return {"id": ont_id, "status": "ok", "source": "obo", "size": owl_path.stat().st_size}
+    except Exception as e:
+        r = None  # fall through to BioPortal
+
+    # 2) BioPortal direct download (acronym is the uppercased id)
+    owl_path.unlink(missing_ok=True)
+    try:
+        bp = _curl(BP_URL.format(ID=ont_id.upper(), key=BP_API_KEY), owl_path, max_time)
+        if bp.returncode == 0 and owl_path.exists() and owl_path.stat().st_size > min_size:
+            return {"id": ont_id, "status": "ok", "source": "bioportal", "size": owl_path.stat().st_size}
+        size = owl_path.stat().st_size if owl_path.exists() else 0
+        owl_path.unlink(missing_ok=True)
+        return {"id": ont_id, "status": "failed", "size_seen": size,
+                "error": (bp.stderr or "").strip()[:160] or "both OBO and BioPortal failed"}
+    except Exception as e:
+        owl_path.unlink(missing_ok=True)
+        return {"id": ont_id, "status": "error", "error": str(e)[:160]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dest", type=Path, help="ontologies root, e.g. /data/aberowl/ontologies")
+    ap.add_argument("--ids", nargs="+", default=[])
+    ap.add_argument("--ids-file", type=Path)
+    ap.add_argument("--workers", type=int, default=4)
+    ap.add_argument("--min-size", type=int, default=20000, help="bytes; smaller = junk (default 20KB)")
+    ap.add_argument("--max-time", type=int, default=1800, help="curl timeout seconds (default 1800)")
+    ap.add_argument("--results-json", type=Path)
+    args = ap.parse_args()
+
+    ids = list(args.ids)
+    if args.ids_file:
+        ids += [ln.strip() for ln in args.ids_file.read_text().splitlines() if ln.strip()]
+    ids = sorted(set(ids))
+    if not ids:
+        ap.error("provide --ids or --ids-file")
+
+    print(f"Retrying {len(ids)} ontologies into {args.dest} (min-size {args.min_size}B)\n")
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(retry_one, i, args.dest, args.min_size, args.max_time): i for i in ids}
+        for f in as_completed(futs):
+            r = f.result()
+            results.append(r)
+            if r["status"] in ("ok", "exists"):
+                mb = r.get("size", 0) / 1024 / 1024
+                src = r.get("source", "disk")
+                print(f"  [{r['status']:6s}] {r['id']:16s} {mb:7.1f} MB  ({src})")
+            else:
+                print(f"  [FAIL  ] {r['id']:16s} {r.get('error','?')[:70]}")
+
+    ok = [r for r in results if r["status"] == "ok"]
+    exists = [r for r in results if r["status"] == "exists"]
+    fail = [r for r in results if r["status"] not in ("ok", "exists")]
+    print(f"\nRecovered: {len(ok)}  Already present: {len(exists)}  Still failing: {len(fail)}")
+    if fail:
+        print("Still failing:", sorted(r["id"] for r in fail))
+    if args.results_json:
+        args.results_json.write_text(json.dumps(results, indent=2))
+        print(f"\nWrote {args.results_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/results/after_cache.json
+++ b/results/after_cache.json
@@ -1,0 +1,52 @@
+{
+  "base_url": "http://localhost:8000",
+  "ontology": "go",
+  "registry_size": 102,
+  "n_iterations": 30,
+  "results": [
+    {
+      "label": "getOntology (O(n) Redis scan)",
+      "n": 30,
+      "mean_ms": 2.1,
+      "median_ms": 2.0,
+      "p95_ms": 3.0,
+      "p99_ms": 3.3,
+      "min_ms": 1.6,
+      "max_ms": 3.3
+    },
+    {
+      "label": "dlquery_all owl:Thing direct subclasses (root hierarchy load)",
+      "n": 30,
+      "mean_ms": 10.3,
+      "median_ms": 11.0,
+      "p95_ms": 13.3,
+      "p99_ms": 14.3,
+      "min_ms": 5.9,
+      "max_ms": 14.3
+    },
+    {
+      "label": "dlquery_all named class subclasses (GO_0008150)",
+      "error": "HTTP 429: http://localhost:8000/api/dlquery_all params={'query': '<http://purl.obolibrary.org/obo/GO_0008150>', 'type': 'subclass', 'ontologies': 'go', 'direct': 'true', 'labels': 'true'}"
+    },
+    {
+      "label": "getClass ES lookup",
+      "n": 30,
+      "mean_ms": 4.3,
+      "median_ms": 4.3,
+      "p95_ms": 5.2,
+      "p99_ms": 6.0,
+      "min_ms": 3.3,
+      "max_ms": 6.0
+    },
+    {
+      "label": "listOntologies (O(n) Redis scan)",
+      "n": 30,
+      "mean_ms": 2.2,
+      "median_ms": 2.2,
+      "p95_ms": 2.6,
+      "p99_ms": 2.8,
+      "min_ms": 1.8,
+      "max_ms": 2.8
+    }
+  ]
+}

--- a/results/baseline.json
+++ b/results/baseline.json
@@ -1,0 +1,58 @@
+{
+  "base_url": "http://localhost:8000",
+  "ontology": "go",
+  "registry_size": 102,
+  "n_iterations": 30,
+  "results": [
+    {
+      "label": "getOntology (O(n) Redis scan)",
+      "n": 30,
+      "mean_ms": 2.3,
+      "median_ms": 2.4,
+      "p95_ms": 3.1,
+      "p99_ms": 3.4,
+      "min_ms": 1.7,
+      "max_ms": 3.4
+    },
+    {
+      "label": "dlquery_all owl:Thing direct subclasses (root hierarchy load)",
+      "n": 30,
+      "mean_ms": 2119.0,
+      "median_ms": 2059.8,
+      "p95_ms": 2489.7,
+      "p99_ms": 2528.4,
+      "min_ms": 1800.0,
+      "max_ms": 2528.4
+    },
+    {
+      "label": "dlquery_all named class subclasses (GO_0008150)",
+      "n": 30,
+      "mean_ms": 32.1,
+      "median_ms": 30.3,
+      "p95_ms": 38.3,
+      "p99_ms": 47.8,
+      "min_ms": 28.1,
+      "max_ms": 47.8
+    },
+    {
+      "label": "getClass ES lookup",
+      "n": 30,
+      "mean_ms": 5.4,
+      "median_ms": 4.9,
+      "p95_ms": 8.1,
+      "p99_ms": 8.1,
+      "min_ms": 3.7,
+      "max_ms": 8.1
+    },
+    {
+      "label": "listOntologies (O(n) Redis scan)",
+      "n": 30,
+      "mean_ms": 2.3,
+      "median_ms": 2.3,
+      "p95_ms": 2.8,
+      "p99_ms": 2.8,
+      "min_ms": 2.1,
+      "max_ms": 2.8
+    }
+  ]
+}

--- a/results/worker_measurements_2026-06-04.md
+++ b/results/worker_measurements_2026-06-04.md
@@ -1,0 +1,47 @@
+# Fleet redistribution — measured memory ledger (2026-06-04)
+
+Empirical right-sizing during the xs-first deploy. For each worker we launch
+generous (`--memory=16g -Xmx12g`), load + warm with sample queries (findRoot +
+subclass DL query per ontology), force a full GC to read the true live heap,
+then recreate trimmed and record the result here.
+
+Key insight: warm RSS at a generous -Xmx is inflated by deferred G1 garbage and
+never returned to the OS. The **live heap after a forced full GC** is the real
+working-set signal. Deployed size ≈ ~2× live heap for -Xmx, +2 G non-heap for
+the container limit.
+
+| physical | plan-w | bucket | cfg onts | loaded | plan est | live heap (post-GC) | warm RSS @16G | **deployed** | post-load RSS @deployed | notes |
+|----------|--------|--------|----------|--------|----------|---------------------|---------------|--------------|-------------------------|-------|
+| worker-34 | 31 | xs | 66 | 60 | 9 G | **3.15 G** | 9.4 G | **8 G / -Xmx6g** | 6.09 G (76%) | 6 failed to load (import/parse errors): teo, apadisorders, materialsmine, msv, ope, oboe-sbc. Repointed 60, routing verified. RSS 6.4G/8G stable after 2 days under real traffic. |
+| worker-35 | 33 | xs | 149 | 149 | 8 G | **1.98 G** | — | **8 G / -Xmx6g** | 3.7 G (47%) | **`rdl` (218 MB, 203 cls) PULLED** — it alone drove 11 G live and crash-looped even at 16 G. Without it, 149 onts load in 48 s at 1.98 G. After loader fix, all import-failures load. Repointed 149. |
+| worker-37 | giants | dedicated | 6 | 6 | — | **30 G** | — | **48 G / -Xmx40g** | 38 G (80%) | Quarantined ABox-heavy giants: rdl, lcgft, ror, fast-title, xref-funder-reg, nlmvs (huge files, <205 cls each). Repointed. Kept 48G (30G live needs ~40G heap; ~right-sized). Some return empty owl:Thing roots (import-suppression dropped their imported root) — online but flat, accepted tradeoff. Pinned in plan_distribution.py + plan_2026-06-08.json. |
+| worker-38 | 35 | xs | 88 | 88 | 7 G | **4.24 G** | — | **10 G / -Xmx8g** | 6.9 G (69%) | plan-w35 minus its 5 giants. All 88 load (import fix). Repointed. Higher live than other xs workers — includes some heftier onts. |
+| worker-39 | 30 | s | 33 | 33 | 13 G | **1.97 G** | — | **7 G / -Xmx5g** | 3.5 G (50%) | s-bucket new worker, no giants. All 33 load, repointed. Estimate (13G) ~7x over live. |
+
+## Observations / running conclusions
+
+- **xs over-provisioned ~3×.** 60 small ontologies → 3.15 G live, not 9 G.
+  Plan's xs estimates are heavily padded. Trimmed worker-34 from the 9 G plan
+  estimate (16 G measurement alloc) down to 8 G.
+- **Caveat before generalizing:** live-set ratio will differ for large l/xl
+  reasoners (big ontologies = big live sets). Must re-measure a representative
+  large worker before trimming those buckets.
+- **Load failures are real even with files on disk:** import-resolution and
+  parse errors drop ontologies at load time. Repoint only the verified-loaded
+  set (listLoadedOntologies), never the config set.
+- **Repoint triggers a central metadata-refresh storm:** the central server
+  async-fetches getStatistics for each repointed ontology. During that window
+  (~30-60 s) central dlquery can briefly return empty even though the worker
+  serves it directly. Wait before verifying routing, or re-test.
+- **Live heap doesn't track ontology count** — it tracks total class/axiom
+  volume. worker-35 (123 tiny onts) = 2.0 G < worker-34 (60 onts) = 3.15 G.
+  So per-worker measurement is necessary; can't extrapolate from count alone.
+- **Loader fix (RequestManager.groovy):** owl:imports now suppressed entirely
+  (SILENT + IRI mapper → /data/.noimport/ non-existent paths, no network). Dead
+  imports were hanging loads 600+s; reachable ones OOM'd workers. Measure on the
+  FULL load now — partial-load trims undersize workers whose recovered onts are
+  big. Restart a worker to pick up the loader (mounted source).
+- **Mis-bucketing:** planner buckets by class count; ABox-heavy ontologies are
+  huge files with few classes → land in xs → OOM. Quarantine by FILE SIZE. The 6
+  giants (rdl/lcgft/ror/fast-title/xref-funder-reg/nlmvs) → dedicated worker-37
+  (30 G live combined). Pull giants from any small-worker config before launch.

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Quick latency comparison: new beta (aberowl2) vs old aberowl, same DL queries."""
+import argparse, statistics, time, sys
+import requests
+from urllib.parse import quote
+
+NEW = "https://beta.aber-owl.net"
+OLD = "http://aberowl.aber-owl.net"
+
+OWL_THING = "<http://www.w3.org/2002/07/owl#Thing>"
+
+# Endpoint contracts differ:
+#   new: /api/dlquery_all?ontologies=<lower>&...
+#   old: /api/dlquery?ontology=<UPPER>&...
+def url_new(ont_id, query, qtype="subclass", direct="false"):
+    return f"{NEW}/api/dlquery_all?ontologies={ont_id}&type={qtype}&direct={direct}&labels=true&query={quote(query)}"
+
+def url_old(ont_id, query, qtype="subclass", direct="false"):
+    return f"{OLD}/api/dlquery?ontology={ont_id}&type={qtype}&direct={direct}&query={quote(query)}"
+
+CASES = [
+    # (label, new-ont-id, old-ont-id, query, qtype, direct)
+    ("GO roots",                       "go",    "GO",    OWL_THING, "subclass", "true"),
+    ("GO 'part of' apoptotic process", "go",    "GO",    "<http://purl.obolibrary.org/obo/BFO_0000050> some <http://purl.obolibrary.org/obo/GO_0006915>", "subclass", "false"),
+    ("MONDO roots",                    "mondo", "MONDO", OWL_THING, "subclass", "true"),
+    ("CHEBI roots",                    "chebi", "CHEBI", OWL_THING, "subclass", "true"),
+    ("NCIT roots",                     "ncit",  "NCIT",  OWL_THING, "subclass", "true"),
+    ("FMA roots",                      "fma",   "FMA",   OWL_THING, "subclass", "true"),
+]
+
+def run(session, url, n, warmup, timeout):
+    times, count = [], None
+    for i in range(warmup + n):
+        try:
+            t0 = time.perf_counter()
+            r = session.get(url, timeout=timeout)
+            ms = (time.perf_counter() - t0) * 1000
+            r.raise_for_status()
+            body = r.json()
+            count = len(body.get("result") or [])
+            if i >= warmup:
+                times.append(ms)
+        except Exception as e:
+            return {"error": str(e)}
+    times.sort()
+    return {
+        "n_results": count,
+        "mean":   round(statistics.mean(times), 1),
+        "median": round(statistics.median(times), 1),
+        "p95":    round(times[int(len(times)*0.95) if len(times) > 1 else 0], 1),
+        "min":    round(times[0], 1),
+        "max":    round(times[-1], 1),
+    }
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=10)
+    ap.add_argument("--warmup", type=int, default=2)
+    ap.add_argument("--timeout", type=int, default=60)
+    args = ap.parse_args()
+
+    s = requests.Session()
+    print(f"{'case':<38} {'side':<5} {'n':>4} {'mean':>8} {'med':>8} {'p95':>8} {'min':>8} {'max':>8}")
+    print("-" * 92)
+    for label, new_id, old_id, query, qtype, direct in CASES:
+        new = run(s, url_new(new_id, query, qtype, direct), args.n, args.warmup, args.timeout)
+        old = run(s, url_old(old_id, query, qtype, direct), args.n, args.warmup, args.timeout)
+        for side, r in (("NEW", new), ("OLD", old)):
+            if "error" in r:
+                print(f"{label:<38} {side:<5} ERROR: {r['error']}")
+            else:
+                print(f"{label:<38} {side:<5} {r['n_results']:>4} {r['mean']:>8.1f} {r['median']:>8.1f} {r['p95']:>8.1f} {r['min']:>8.1f} {r['max']:>8.1f}")
+        if "error" not in new and "error" not in old:
+            ratio = new['mean'] / old['mean'] if old['mean'] > 0 else float('inf')
+            print(f"{'':<38} {'':<5} ratio NEW/OLD = {ratio:.1f}x")
+        print()
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_dispatch.py
+++ b/scripts/bench_dispatch.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Compare central-server dispatch shapes against a multi-ontology worker.
+
+Mode A — "old" (current prod): N parallel HTTP calls, one per ontology,
+dispatched via asyncio.gather (mirroring central_server/app/main.py:700).
+
+Mode B — "new" (option B): 1 HTTP call with ontologyIds=a,b,c,...
+"""
+import argparse, asyncio, json, statistics, sys, time
+import aiohttp
+
+BASE = "http://localhost:8081/api"
+
+
+async def call_single(session, ontology_id, query, qtype, direct, labels):
+    params = {
+        "ontologyId": ontology_id,
+        "query": query,
+        "type": qtype,
+        "direct": direct,
+        "labels": labels,
+    }
+    async with session.get(f"{BASE}/runQuery.groovy", params=params, timeout=30) as r:
+        body = await r.json()
+        return body.get("result", [])
+
+
+async def mode_old(session, onts, query, qtype, direct, labels):
+    """Fan-out N HTTP calls, gather all."""
+    tasks = [
+        call_single(session, o, query, qtype, direct, labels) for o in onts
+    ]
+    chunks = await asyncio.gather(*tasks)
+    out = []
+    for c, ont in zip(chunks, onts):
+        for entry in c:
+            entry["ontology"] = ont
+        out.extend(c)
+    return out
+
+
+async def mode_new(session, onts, query, qtype, direct, labels):
+    """One HTTP call with ontologyIds=a,b,c."""
+    params = {
+        "ontologyIds": ",".join(onts),
+        "query": query,
+        "type": qtype,
+        "direct": direct,
+        "labels": labels,
+    }
+    async with session.get(f"{BASE}/runQuery.groovy", params=params, timeout=30) as r:
+        body = await r.json()
+        return body.get("result", [])
+
+
+async def time_run(coro_factory, n, warmup):
+    times = []
+    last_count = 0
+    async with aiohttp.ClientSession() as session:
+        for i in range(warmup + n):
+            t0 = time.perf_counter()
+            r = await coro_factory(session)
+            ms = (time.perf_counter() - t0) * 1000
+            last_count = len(r)
+            if i >= warmup:
+                times.append(ms)
+    times.sort()
+    return {
+        "n_results": last_count,
+        "mean": round(statistics.mean(times), 1),
+        "median": round(statistics.median(times), 1),
+        "p95": round(times[int(len(times)*0.95) if len(times) > 1 else 0], 1),
+        "min": round(times[0], 1),
+        "max": round(times[-1], 1),
+    }
+
+
+CASES = [
+    # (label, query, type, direct, labels)
+    ("owl:Thing roots (direct=true)",
+     "<http://www.w3.org/2002/07/owl#Thing>", "subclass", "true", "true"),
+    ("GO existential (only go has axioms)",
+     "<http://purl.obolibrary.org/obo/BFO_0000050> some <http://purl.obolibrary.org/obo/GO_0006915>",
+     "subclass", "false", "true"),
+]
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=10)
+    ap.add_argument("--warmup", type=int, default=2)
+    ap.add_argument(
+        "--ontologies", default="pizza,go,bfo,ro,iao,so",
+        help="comma-separated ontology ids loaded on local worker"
+    )
+    args = ap.parse_args()
+    onts = [o.strip() for o in args.ontologies.split(",") if o.strip()]
+    print(f"Worker: {BASE}")
+    print(f"Ontologies: {onts}")
+    print(f"Runs: {args.n} (after {args.warmup} warmup)\n")
+
+    for label, query, qtype, direct, labels in CASES:
+        print(f"=== {label} ===")
+        old = await time_run(
+            lambda s, q=query, t=qtype, d=direct, l=labels:
+                mode_old(s, onts, q, t, d, l),
+            args.n, args.warmup,
+        )
+        new = await time_run(
+            lambda s, q=query, t=qtype, d=direct, l=labels:
+                mode_new(s, onts, q, t, d, l),
+            args.n, args.warmup,
+        )
+        print(f"  {'mode':<8} {'n':>4} {'mean':>8} {'med':>8} {'p95':>8} {'min':>8} {'max':>8}")
+        print(f"  {'old (N calls)':<8} {old['n_results']:>4} {old['mean']:>8.1f} {old['median']:>8.1f} {old['p95']:>8.1f} {old['min']:>8.1f} {old['max']:>8.1f}")
+        print(f"  {'new (1 call)':<8} {new['n_results']:>4} {new['mean']:>8.1f} {new['median']:>8.1f} {new['p95']:>8.1f} {new['min']:>8.1f} {new['max']:>8.1f}")
+        ratio = old['mean'] / new['mean'] if new['mean'] > 0 else float('inf')
+        print(f"  speedup: {ratio:.2f}x")
+        if old['n_results'] != new['n_results']:
+            print(f"  WARNING: result counts differ — {old['n_results']} vs {new['n_results']}")
+        print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/bench_hierarchy.py
+++ b/scripts/bench_hierarchy.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Focused hierarchy-load benchmark.
+
+Times the exact endpoint the UI hits when a user clicks an ontology:
+GET /api/dlquery_all?query=<owl:Thing>&type=subclass&direct=true&labels=true&ontologies=<id>
+
+Also times one named-class expansion (clicking a sub-node).
+
+Usage:
+    python scripts/bench_hierarchy.py --url https://beta.aber-owl.net \
+        --ontologies go,hp,mondo --n 10 \
+        --json results/deploy_YYYYMMDD/before.json
+"""
+import argparse, json, statistics, time, sys
+import requests
+
+OWL_THING = "http://www.w3.org/2002/07/owl#Thing"
+# Per-ontology probe class for "click a child" scenario.
+NAMED_CLASS = {
+    "go":    "http://purl.obolibrary.org/obo/GO_0008150",   # biological_process
+    "hp":    "http://purl.obolibrary.org/obo/HP_0000118",   # phenotypic abnormality
+    "mondo": "http://purl.obolibrary.org/obo/MONDO_0000001",
+    "mp":    "http://purl.obolibrary.org/obo/MP_0000001",
+    "uberon":"http://purl.obolibrary.org/obo/UBERON_0001062",
+    "ncit":  "http://purl.obolibrary.org/obo/NCIT_C7057",
+}
+
+def timed(session, url, params, timeout):
+    t0 = time.perf_counter()
+    r = session.get(url, params=params, timeout=timeout)
+    ms = (time.perf_counter() - t0) * 1000
+    r.raise_for_status()
+    n_results = 0
+    try:
+        body = r.json()
+        n_results = len(body.get("result") or body.get("results") or [])
+    except Exception:
+        pass
+    return ms, n_results
+
+def run(label, fn, n, warmup):
+    print(f"  {label:55s} ", end="", flush=True)
+    times, last_n = [], None
+    for i in range(warmup + n):
+        try:
+            ms, last_n = fn()
+            if i >= warmup:
+                times.append(ms)
+        except Exception as e:
+            print(f"\n    SKIP: {e}")
+            return {"label": label, "error": str(e)}
+    times.sort()
+    out = {
+        "label": label, "n": n, "n_results": last_n,
+        "mean_ms":   round(statistics.mean(times), 1),
+        "median_ms": round(statistics.median(times), 1),
+        "p95_ms":    round(times[int(len(times)*0.95) if len(times) > 1 else 0], 1),
+        "min_ms":    round(times[0], 1),
+        "max_ms":    round(times[-1], 1),
+    }
+    print(f"mean={out['mean_ms']:>7.1f}  med={out['median_ms']:>7.1f}  "
+          f"p95={out['p95_ms']:>7.1f}  min={out['min_ms']:>7.1f}  n_results={last_n}")
+    return out
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--url", default="https://beta.aber-owl.net")
+    p.add_argument("--ontologies", default="go,hp,mondo")
+    p.add_argument("--n", type=int, default=10)
+    p.add_argument("--warmup", type=int, default=2)
+    p.add_argument("--timeout", type=int, default=90)
+    p.add_argument("--json", dest="json_out", default=None)
+    args = p.parse_args()
+
+    base = args.url.rstrip("/")
+    session = requests.Session()
+    out = {"base_url": base, "n": args.n, "warmup": args.warmup, "scenarios": []}
+    ontologies = [o.strip() for o in args.ontologies.split(",") if o.strip()]
+
+    for ont in ontologies:
+        print(f"\n== ontology={ont} ==")
+        # Root hierarchy (owl:Thing direct subclasses)
+        r1 = run(
+            f"[{ont}] roots (owl:Thing direct subclasses)",
+            lambda o=ont: timed(session, f"{base}/api/dlquery_all", {
+                "query": f"<{OWL_THING}>", "type": "subclass",
+                "ontologies": o, "direct": "true", "labels": "true",
+            }, args.timeout),
+            args.n, args.warmup)
+        r1["ontology"] = ont
+        r1["scenario"] = "roots"
+        out["scenarios"].append(r1)
+
+        # Named-class expansion (user clicks a tree node)
+        iri = NAMED_CLASS.get(ont)
+        if iri:
+            r2 = run(
+                f"[{ont}] expand {iri.rsplit('/',1)[-1]} direct subclasses",
+                lambda o=ont, q=iri: timed(session, f"{base}/api/dlquery_all", {
+                    "query": f"<{q}>", "type": "subclass",
+                    "ontologies": o, "direct": "true", "labels": "true",
+                }, args.timeout),
+                args.n, args.warmup)
+            r2["ontology"] = ont
+            r2["scenario"] = "expand_named"
+            r2["named_iri"] = iri
+            out["scenarios"].append(r2)
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(out, f, indent=2)
+        print(f"\nSaved {args.json_out}")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Benchmark key AberOWL API endpoints before/after performance fixes.
+
+Measures wall-clock latency (ms) for the endpoints most affected by the
+O(n) Redis scan and worker-side toInfo() issues:
+
+  1. getOntology         — O(n) Redis hvals scan, find one entry
+  2. dlquery_all roots   — O(n) scan + worker: direct subclasses of owl:Thing
+  3. dlquery_all class   — O(n) scan + worker: subclasses of a named class
+  4. getClass            — ES lookup (should be fast regardless)
+
+Usage:
+    python scripts/benchmark.py                          # defaults
+    python scripts/benchmark.py --ontology go --n 30
+    python scripts/benchmark.py --url http://localhost:8000 --ontology pizza --n 20
+    python scripts/benchmark.py --json results.json      # save raw timings
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from typing import Callable
+
+import requests
+
+OWL_THING = "http://www.w3.org/2002/07/owl#Thing"
+
+# A class IRI that exists in GO; override with --class-iri for other ontologies.
+DEFAULT_CLASS_IRI = "http://purl.obolibrary.org/obo/GO_0008150"  # biological_process
+
+
+def timed_get(session: requests.Session, url: str, params: dict) -> float:
+    """Return elapsed time in ms for a successful GET, or raise on error."""
+    t0 = time.perf_counter()
+    r = session.get(url, params=params, timeout=60)
+    elapsed = (time.perf_counter() - t0) * 1000
+    if not r.ok:
+        raise RuntimeError(f"HTTP {r.status_code}: {url} params={params}")
+    return elapsed
+
+
+def run_scenario(
+    label: str,
+    fn: Callable[[], float],
+    n: int,
+    warmup: int = 2,
+) -> dict:
+    """Run fn() n+warmup times; discard warmup, return stats dict."""
+    print(f"  {label} ... ", end="", flush=True)
+    times = []
+    for i in range(warmup + n):
+        try:
+            ms = fn()
+            if i >= warmup:
+                times.append(ms)
+        except Exception as e:
+            print(f"\n    SKIP (error: {e})")
+            return {"label": label, "error": str(e)}
+
+    times.sort()
+    result = {
+        "label": label,
+        "n": n,
+        "mean_ms": round(statistics.mean(times), 1),
+        "median_ms": round(statistics.median(times), 1),
+        "p95_ms": round(times[int(len(times) * 0.95)], 1),
+        "p99_ms": round(times[min(int(len(times) * 0.99), len(times) - 1)], 1),
+        "min_ms": round(times[0], 1),
+        "max_ms": round(times[-1], 1),
+    }
+    print(f"mean={result['mean_ms']}ms  median={result['median_ms']}ms  "
+          f"p95={result['p95_ms']}ms  p99={result['p99_ms']}ms")
+    return result
+
+
+def count_registry_entries(base_url: str, session: requests.Session) -> int:
+    try:
+        r = session.get(f"{base_url}/api/servers", timeout=10)
+        return len(r.json())
+    except Exception:
+        return -1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark AberOWL API endpoints.")
+    parser.add_argument("--url", default="http://localhost:8000", help="Central server base URL")
+    parser.add_argument("--ontology", default="go", help="Ontology ID to query against")
+    parser.add_argument("--class-iri", default=DEFAULT_CLASS_IRI,
+                        help="Class IRI for the named-class DL query scenario")
+    parser.add_argument("--n", type=int, default=20, help="Iterations per scenario (excl. warmup)")
+    parser.add_argument("--warmup", type=int, default=3, help="Warmup iterations to discard")
+    parser.add_argument("--json", dest="json_out", default=None,
+                        help="Save raw results to this JSON file")
+    args = parser.parse_args()
+
+    base = args.url.rstrip("/")
+    ont = args.ontology
+    class_iri = args.class_iri
+    class_q = f"<{class_iri}>"
+
+    session = requests.Session()
+
+    # Check server is up
+    try:
+        session.get(f"{base}/api/servers", timeout=5).raise_for_status()
+    except Exception as e:
+        print(f"Cannot reach central server at {base}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    n_entries = count_registry_entries(base, session)
+    print(f"\nBenchmarking {base}  ontology={ont}  registry_size={n_entries}  n={args.n}\n")
+
+    scenarios = [
+        (
+            "getOntology (O(n) Redis scan)",
+            lambda: timed_get(session, f"{base}/api/getOntology", {"ontology": ont}),
+        ),
+        (
+            "dlquery_all owl:Thing direct subclasses (root hierarchy load)",
+            lambda: timed_get(session, f"{base}/api/dlquery_all", {
+                "query": f"<{OWL_THING}>",
+                "type": "subclass",
+                "ontologies": ont,
+                "direct": "true",
+                "labels": "true",
+            }),
+        ),
+        (
+            f"dlquery_all named class subclasses ({class_iri.rsplit('/', 1)[-1]})",
+            lambda: timed_get(session, f"{base}/api/dlquery_all", {
+                "query": class_q,
+                "type": "subclass",
+                "ontologies": ont,
+                "direct": "true",
+                "labels": "true",
+            }),
+        ),
+        (
+            "getClass ES lookup",
+            lambda: timed_get(session, f"{base}/api/getClass", {
+                "query": class_iri,
+                "ontology": ont,
+            }),
+        ),
+        (
+            "listOntologies (O(n) Redis scan)",
+            lambda: timed_get(session, f"{base}/api/listOntologies", {}),
+        ),
+    ]
+
+    results = []
+    print("Scenarios:")
+    for label, fn in scenarios:
+        r = run_scenario(label, fn, n=args.n, warmup=args.warmup)
+        results.append(r)
+
+    summary = {
+        "base_url": base,
+        "ontology": ont,
+        "registry_size": n_entries,
+        "n_iterations": args.n,
+        "results": results,
+    }
+
+    print(f"\nRegistry entries at time of run: {n_entries}")
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(summary, f, indent=2)
+        print(f"Raw results saved to {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_owl_legacy.groovy
+++ b/scripts/convert_owl_legacy.groovy
@@ -1,0 +1,31 @@
+// Convert an OWL file that only the legacy OWLAPI (4.2.3, as run by the old
+// aberowl) can parse into RDF/XML, which the current worker's OWLAPI 4.5.29
+// reads fine. Use for ontologies that fail to load on 4.5.x due to its stricter
+// Manchester-syntax grammar (e.g. gene-cds: annotation sections placed after
+// axiom sections, which 4.2.3 tolerated and 4.5.29 rejects).
+//
+//   groovy convert_owl_legacy.groovy <input.owl> <output.owl>
+//
+// Missing imports are ignored (SILENT) so a dead owl:imports URL can't stall
+// the conversion.
+@Grapes([
+  @Grab('net.sourceforge.owlapi:owlapi-apibinding:4.2.3'),
+  @Grab('net.sourceforge.owlapi:owlapi-impl:4.2.3'),
+  @Grab('net.sourceforge.owlapi:owlapi-parsers:4.2.3')
+])
+import org.semanticweb.owlapi.apibinding.OWLManager
+import org.semanticweb.owlapi.model.*
+import org.semanticweb.owlapi.io.FileDocumentSource
+import org.semanticweb.owlapi.formats.RDFXMLDocumentFormat
+
+if (args.length < 2) {
+    System.err.println "usage: convert_owl_legacy.groovy <input.owl> <output.owl>"
+    System.exit(2)
+}
+def mgr = OWLManager.createOWLOntologyManager()
+def config = new OWLOntologyLoaderConfiguration()
+        .setMissingImportHandlingStrategy(MissingImportHandlingStrategy.SILENT)
+def ont = mgr.loadOntologyFromOntologyDocument(new FileDocumentSource(new File(args[0])), config)
+println "loaded with OWLAPI 4.2.3: ${ont.getAxiomCount()} axioms, ${ont.getClassesInSignature().size()} classes"
+mgr.saveOntology(ont, new RDFXMLDocumentFormat(), IRI.create(new File(args[1])))
+println "saved RDF/XML -> ${args[1]}"

--- a/scripts/fleet_report.py
+++ b/scripts/fleet_report.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Fleet report: per-worker ontology distribution + sizing metrics + HTML output.
+
+Pulls /api/servers from the central server (default: beta). For ontologies
+without rich metadata in the registry, fills the gap by querying BioPortal's
+/ontologies/{ACRONYM}/metrics endpoint (cached locally so re-runs are cheap).
+
+Outputs a static HTML file with two sections:
+  1. Per-worker table: online/total, totals across hosted ontologies
+     (classes, individuals, properties), biggest ontology, and a size-bucket
+     summary aligned with deploy/plan_workers.py's buckets.
+  2. Per-ontology table (client-side sortable): id, worker, status, source
+     of metrics (aberowl / bioportal / unknown), class/individual/property
+     counts.
+
+Usage:
+    python3 scripts/fleet_report.py
+    python3 scripts/fleet_report.py --no-bioportal      # skip the fill-in
+    python3 scripts/fleet_report.py --output /tmp/r.html
+
+Re-run safely; BioPortal calls are cached to /tmp/bp_metrics_cache.json.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+DEFAULT_CENTRAL = "https://beta.aber-owl.net"
+DEFAULT_BP_APIKEY = "8b5b7825-538d-40e0-9e9e-5ab9274a9aeb"  # same key as deploy/download_ontologies.py
+DEFAULT_CACHE = Path("/tmp/bp_metrics_cache.json")
+DEFAULT_OUTPUT = Path(f"results/fleet_report_{dt.date.today().isoformat()}.html")
+
+# Size buckets aligned with deploy/plan_workers.py for class-count-based grouping.
+# (name, min_classes, max_classes, suggested_per_worker)
+CLASS_BUCKETS = [
+    ("xl",  500_000,  float("inf"), 1),   # huge — dedicated worker
+    ("l",   100_000,  500_000,      2),   # 1-3 per worker
+    ("m",    10_000,  100_000,     10),
+    ("s",     1_000,   10_000,     50),
+    ("xs",        0,    1_000,    200),
+]
+
+
+def fetch_servers(base_url: str, timeout: int = 90) -> list[dict]:
+    # The /api/servers payload is ~864 entries; beta's proxy chain occasionally
+    # stalls — give it a generous timeout instead of erroring at 30s.
+    r = requests.get(f"{base_url.rstrip('/')}/api/servers", timeout=timeout)
+    r.raise_for_status()
+    return r.json()
+
+
+def load_cache(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def save_cache(cache: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cache, indent=2, sort_keys=True))
+
+
+def fetch_bp_metrics(acronym: str, apikey: str, cache: dict, session: requests.Session) -> dict | None:
+    """Return BP /metrics for an acronym, with on-disk cache. Returns None if unavailable."""
+    key = acronym.upper()
+    if key in cache:
+        return cache[key]
+    try:
+        r = session.get(
+            f"https://data.bioontology.org/ontologies/{key}/metrics",
+            params={"apikey": apikey},
+            timeout=15,
+        )
+        if r.status_code != 200:
+            cache[key] = None
+            return None
+        data = r.json()
+        # BP returns metrics; we only keep what we need.
+        out = {
+            "classes": data.get("classes"),
+            "individuals": data.get("individuals"),
+            "properties": data.get("properties"),
+            "max_depth": data.get("maxDepth"),
+            "avg_children": data.get("averageChildCount"),
+        }
+        cache[key] = out
+        return out
+    except Exception:
+        cache[key] = None
+        return None
+
+
+def worker_num(url: str) -> int:
+    try:
+        return int(url.split("aberowl-worker-")[1].rstrip("/").rstrip(":8080"))
+    except (IndexError, ValueError):
+        return 9999
+
+
+def class_bucket(n: int | None) -> str:
+    if not n:
+        return "?"
+    for name, lo, hi, _ in CLASS_BUCKETS:
+        if lo <= n < hi:
+            return name
+    return "?"
+
+
+def gather(servers: list[dict], apikey: str, cache_path: Path, use_bp: bool) -> list[dict]:
+    """Return a normalised list with metrics filled from aberowl or BP."""
+    cache = load_cache(cache_path) if use_bp else {}
+    session = requests.Session() if use_bp else None
+    result = []
+    for o in servers:
+        rec = {
+            "id": o.get("ontology"),
+            "title": o.get("title"),
+            "status": o.get("status"),
+            "url": o.get("url"),
+            "worker": worker_num(o.get("url", "")),
+            "classes": o.get("class_count"),
+            "individuals": o.get("individual_count"),
+            "object_props": o.get("object_property_count"),
+            "data_props": o.get("data_property_count"),
+            "annotation_props": o.get("annotation_property_count"),
+            "axioms": o.get("axiom_count"),
+            "logical_axioms": o.get("logical_axiom_count"),
+            "tbox_axioms": o.get("tbox_axiom_count"),
+            "abox_axioms": o.get("abox_axiom_count"),
+            "rbox_axioms": o.get("rbox_axiom_count"),
+            "dl_expressivity": o.get("dl_expressivity"),
+            "source": "aberowl" if o.get("class_count") else None,
+        }
+        if rec["classes"] is None and use_bp and rec["id"]:
+            bp = fetch_bp_metrics(rec["id"], apikey, cache, session)
+            if bp and bp.get("classes") is not None:
+                rec["classes"] = bp["classes"]
+                rec["individuals"] = bp.get("individuals")
+                rec["object_props"] = bp.get("properties")
+                rec["source"] = "bioportal"
+        if rec["source"] is None:
+            rec["source"] = "unknown"
+        rec["bucket"] = class_bucket(rec["classes"])
+        result.append(rec)
+    if use_bp:
+        save_cache(cache, cache_path)
+    return result
+
+
+def per_worker_summary(records: list[dict]) -> list[dict]:
+    by_worker = defaultdict(list)
+    for r in records:
+        by_worker[r["worker"]].append(r)
+    rows = []
+    for w, onts in sorted(by_worker.items()):
+        online = [o for o in onts if o.get("status") == "online"]
+        bucket_counts = defaultdict(int)
+        for o in onts:
+            bucket_counts[o["bucket"]] += 1
+        biggest = max(onts, key=lambda o: o.get("classes") or 0, default=None)
+        rows.append({
+            "worker": w,
+            "total": len(onts),
+            "online": len(online),
+            "classes_sum": sum((o.get("classes") or 0) for o in onts),
+            "axioms_sum": sum((o.get("logical_axioms") or 0) for o in onts),
+            "individuals_sum": sum((o.get("individuals") or 0) for o in onts),
+            "biggest": biggest["id"] if biggest else None,
+            "biggest_classes": (biggest.get("classes") if biggest else None) or 0,
+            "bucket_counts": dict(bucket_counts),
+        })
+    return rows
+
+
+def render_html(records: list[dict], summary: list[dict], base_url: str) -> str:
+    online = sum(1 for r in records if r["status"] == "online")
+    total = len(records)
+    no_meta = sum(1 for r in records if r["source"] == "unknown")
+    bp_meta = sum(1 for r in records if r["source"] == "bioportal")
+
+    # Helpers
+    def fnum(n):
+        return f"{n:,}" if (n is not None and n != 0) else "—"
+    def cell(s):
+        return html.escape(str(s) if s is not None else "—")
+
+    bucket_legend = " · ".join(
+        f"<b>{b[0]}</b>: ≥{b[1]:,} classes ({b[3]}/worker)" for b in CLASS_BUCKETS
+    )
+
+    # Per-worker rows
+    worker_rows_html = []
+    for s in summary:
+        bcs = s["bucket_counts"]
+        bucket_str = " ".join(
+            f"<span class=bucket_{b}>{b}:{bcs.get(b, 0)}</span>"
+            for b in ("xl", "l", "m", "s", "xs", "?") if bcs.get(b)
+        )
+        worker_rows_html.append(
+            f"<tr><td>worker-{s['worker']}</td>"
+            f"<td>{s['online']}/{s['total']}</td>"
+            f"<td class=num>{fnum(s['classes_sum'])}</td>"
+            f"<td class=num>{fnum(s['axioms_sum'])}</td>"
+            f"<td class=num>{fnum(s['individuals_sum'])}</td>"
+            f"<td>{cell(s['biggest'])} ({fnum(s['biggest_classes'])})</td>"
+            f"<td>{bucket_str}</td></tr>"
+        )
+
+    # Per-ontology rows
+    ont_rows_html = []
+    for r in sorted(records, key=lambda x: (-(x.get("classes") or 0), x["id"] or "")):
+        ont_rows_html.append(
+            f"<tr class=row_{r['status']} bucket={r['bucket']}>"
+            f"<td>{cell(r['id'])}</td>"
+            f"<td>worker-{r['worker']}</td>"
+            f"<td class=status_{r['status']}>{cell(r['status'])}</td>"
+            f"<td class=src_{r['source']}>{cell(r['source'])}</td>"
+            f"<td>{cell(r['bucket'])}</td>"
+            f"<td class=num>{fnum(r['classes'])}</td>"
+            f"<td class=num>{fnum(r['individuals'])}</td>"
+            f"<td class=num>{fnum(r['object_props'])}</td>"
+            f"<td class=num>{fnum(r['logical_axioms'])}</td>"
+            f"<td>{cell(r['dl_expressivity'])}</td>"
+            f"</tr>"
+        )
+
+    return f"""<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>aberowl2 fleet report {dt.date.today().isoformat()}</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; margin: 20px; color: #222; }}
+  h1, h2 {{ color: #111; }}
+  table {{ border-collapse: collapse; margin: 10px 0; font-size: 13px; }}
+  th, td {{ padding: 4px 8px; border-bottom: 1px solid #ddd; text-align: left; }}
+  th {{ background: #f4f4f4; cursor: pointer; user-select: none; }}
+  th:hover {{ background: #e8e8e8; }}
+  td.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  .status_online {{ color: #060; }}
+  .status_offline {{ color: #c33; }}
+  .src_aberowl {{ color: #444; }}
+  .src_bioportal {{ color: #06a; }}
+  .src_unknown {{ color: #999; font-style: italic; }}
+  .bucket_xl {{ background: #fdd; padding: 1px 4px; border-radius: 3px; }}
+  .bucket_l {{ background: #fed; padding: 1px 4px; border-radius: 3px; }}
+  .bucket_m {{ background: #ffd; padding: 1px 4px; border-radius: 3px; }}
+  .bucket_s {{ background: #dfd; padding: 1px 4px; border-radius: 3px; }}
+  .bucket_xs {{ background: #ddf; padding: 1px 4px; border-radius: 3px; }}
+  .legend {{ font-size: 12px; color: #555; margin: 5px 0; }}
+  input[type=search] {{ padding: 4px; width: 220px; }}
+</style>
+</head><body>
+<h1>aberowl2 fleet report</h1>
+<p><b>Source:</b> {html.escape(base_url)} &middot;
+   <b>Generated:</b> {dt.datetime.now().isoformat(timespec='seconds')} &middot;
+   <b>Total:</b> {total} ontologies &middot;
+   <b>Online:</b> {online} &middot;
+   <b>Offline:</b> {total - online}</p>
+<p class=legend>Metadata sources: aberowl ({sum(1 for r in records if r['source']=='aberowl')}),
+   bioportal-fallback ({bp_meta}), unknown ({no_meta}). &middot;
+   Class buckets: {bucket_legend}.</p>
+
+<h2>Per-worker distribution</h2>
+<table id=workers>
+<thead><tr>
+<th>worker</th><th>online/total</th><th>total classes</th><th>logical axioms</th>
+<th>individuals</th><th>biggest</th><th>buckets</th>
+</tr></thead>
+<tbody>
+{''.join(worker_rows_html)}
+</tbody></table>
+
+<h2>Per-ontology metrics</h2>
+<p>Filter: <input type=search id=filter placeholder="ontology id or worker..."></p>
+<table id=ontologies>
+<thead><tr>
+<th data-sort=str>id</th>
+<th data-sort=str>worker</th>
+<th data-sort=str>status</th>
+<th data-sort=str>source</th>
+<th data-sort=str>bucket</th>
+<th data-sort=num>classes</th>
+<th data-sort=num>individuals</th>
+<th data-sort=num>object props</th>
+<th data-sort=num>logical axioms</th>
+<th data-sort=str>DL expressivity</th>
+</tr></thead>
+<tbody id=ontology_body>
+{''.join(ont_rows_html)}
+</tbody></table>
+
+<script>
+// minimal client-side sorting + filter
+(function() {{
+  const table = document.getElementById('ontologies');
+  const tbody = document.getElementById('ontology_body');
+  table.querySelectorAll('thead th').forEach((th, i) => {{
+    th.addEventListener('click', () => {{
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      const numCmp = th.dataset.sort === 'num';
+      const dir = th.dataset.dir === 'asc' ? 'desc' : 'asc';
+      th.dataset.dir = dir;
+      rows.sort((a, b) => {{
+        const av = a.children[i].textContent.replace(/,/g, '').trim();
+        const bv = b.children[i].textContent.replace(/,/g, '').trim();
+        if (numCmp) {{
+          const an = parseFloat(av) || (av === '—' ? -1 : 0);
+          const bn = parseFloat(bv) || (bv === '—' ? -1 : 0);
+          return dir === 'asc' ? an - bn : bn - an;
+        }} else {{
+          return dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+        }}
+      }});
+      rows.forEach(r => tbody.appendChild(r));
+    }});
+  }});
+  document.getElementById('filter').addEventListener('input', e => {{
+    const q = e.target.value.toLowerCase();
+    tbody.querySelectorAll('tr').forEach(r => {{
+      r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none';
+    }});
+  }});
+}})();
+</script>
+</body></html>"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default=DEFAULT_CENTRAL,
+                    help="central server base URL (default: %(default)s)")
+    ap.add_argument("--bioportal-apikey", default=os.environ.get("BIOPORTAL_APIKEY", DEFAULT_BP_APIKEY),
+                    help="BioPortal API key (default: deploy/download_ontologies.py key)")
+    ap.add_argument("--no-bioportal", action="store_true",
+                    help="don't fill missing metadata from BioPortal")
+    ap.add_argument("--cache", type=Path, default=DEFAULT_CACHE,
+                    help="BioPortal response cache path")
+    ap.add_argument("--output", "-o", type=Path, default=DEFAULT_OUTPUT,
+                    help="HTML output path")
+    args = ap.parse_args()
+
+    print(f"Fetching /api/servers from {args.url}...", flush=True)
+    servers = fetch_servers(args.url)
+    print(f"  got {len(servers)} entries", flush=True)
+
+    use_bp = not args.no_bioportal
+    if use_bp:
+        missing = sum(1 for o in servers if not o.get("class_count"))
+        print(f"BioPortal fill-in for {missing} entries lacking metadata (cache={args.cache})...", flush=True)
+
+    records = gather(servers, args.bioportal_apikey, args.cache, use_bp)
+
+    sources = defaultdict(int)
+    for r in records:
+        sources[r["source"]] += 1
+    print(f"  metadata sources: aberowl={sources['aberowl']}, "
+          f"bioportal={sources['bioportal']}, unknown={sources['unknown']}", flush=True)
+
+    summary = per_worker_summary(records)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_html(records, summary, args.url))
+    print(f"Wrote {args.output}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inspect_ontology.groovy
+++ b/scripts/inspect_ontology.groovy
@@ -1,0 +1,62 @@
+// Standalone OWL inspector. Reports class / property / individual / axiom
+// counts for an OWL file, using OWLAPI 4.5.29 (same as the workers).
+//
+// Run from inside a worker container (which already has OWLAPI grapes
+// available), e.g.:
+//   docker exec aberowl-worker-1 groovy /scripts/inspect_ontology.groovy /data/ddss/ddss.owl
+//
+// Output is a single JSON line on stdout so it's easy to parse.
+
+@Grab('net.sourceforge.owlapi:owlapi-distribution:4.5.29')
+@Grab('org.semanticweb.elk:elk-owlapi:0.4.3')
+import org.semanticweb.owlapi.apibinding.OWLManager
+import org.semanticweb.owlapi.model.*
+import org.semanticweb.owlapi.util.DLExpressivityChecker
+
+if (args.length < 1) {
+    System.err.println("usage: inspect_ontology.groovy <path-to.owl>")
+    System.exit(2)
+}
+def path = args[0]
+def file = new File(path)
+if (!file.exists()) {
+    System.err.println("file not found: ${path}")
+    System.exit(1)
+}
+
+def manager = OWLManager.createOWLOntologyManager()
+def ontology = manager.loadOntologyFromOntologyDocument(file)
+
+def classes        = ontology.getClassesInSignature(true).size()
+def individuals    = ontology.getIndividualsInSignature(true).size()
+def object_props   = ontology.getObjectPropertiesInSignature(true).size()
+def data_props     = ontology.getDataPropertiesInSignature(true).size()
+def annot_props    = ontology.getAnnotationPropertiesInSignature(true).size()
+def axioms         = ontology.getAxiomCount()
+def logical_axioms = ontology.getLogicalAxiomCount()
+def tbox = ontology.getTBoxAxioms(org.semanticweb.owlapi.model.parameters.Imports.INCLUDED).size()
+def abox = ontology.getABoxAxioms(org.semanticweb.owlapi.model.parameters.Imports.INCLUDED).size()
+def rbox = ontology.getRBoxAxioms(org.semanticweb.owlapi.model.parameters.Imports.INCLUDED).size()
+
+def dl = "?"
+try {
+    dl = new DLExpressivityChecker([ontology]).getDescriptionLogicName()
+} catch (Exception e) { /* ignore */ }
+
+def file_size = file.length()
+
+println groovy.json.JsonOutput.toJson([
+    path: path,
+    file_size: file_size,
+    classes: classes,
+    individuals: individuals,
+    object_props: object_props,
+    data_props: data_props,
+    annotation_props: annot_props,
+    axioms: axioms,
+    logical_axioms: logical_axioms,
+    tbox: tbox,
+    abox: abox,
+    rbox: rbox,
+    dl_expressivity: dl,
+])

--- a/scripts/normalize_manchester_annotations.py
+++ b/scripts/normalize_manchester_annotations.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Normalize malformed Manchester-syntax OWL files that pack multiple
+`Annotations:` keyword sections onto a single line, e.g.:
+
+    Annotations: rsid "rs1208"    Annotations: rdfs:label "rs1208"    Annotations: relevant_for NAT2
+
+OWLAPI 4.5.29's Manchester parser rejects this (older OWLAPI versions, like the
+one the legacy aberowl runs, tolerated it). Splitting each inline `Annotations:`
+onto its own line is semantically identical — repeated `Annotations:` sections
+in a frame are additive — and parses cleanly.
+
+The split is quote-aware: an `Annotations:` occurring inside a "double-quoted"
+string literal is left untouched. Files are only rewritten if they actually
+contain the malformation, and the original is backed up to <file>.orig.
+
+Usage:
+    # scan only (no writes) — report affected files
+    python3 scripts/normalize_manchester_annotations.py /data/aberowl/ontologies --scan
+    # fix specific files
+    python3 scripts/normalize_manchester_annotations.py --apply FILE [FILE ...]
+    # fix every affected file under a root
+    python3 scripts/normalize_manchester_annotations.py /data/aberowl/ontologies --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def annotation_keyword_positions(line: str) -> list[int]:
+    """Offsets of 'Annotations:' keyword occurrences that are OUTSIDE quotes."""
+    pos = []
+    in_q = False
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if c == '"':
+            in_q = not in_q
+            i += 1
+        elif not in_q and line.startswith("Annotations:", i):
+            pos.append(i)
+            i += len("Annotations:")
+        else:
+            i += 1
+    return pos
+
+
+def split_line(line: str) -> list[str]:
+    """Split a line carrying >1 inline 'Annotations:' into one per line."""
+    body = line.rstrip("\n")
+    positions = annotation_keyword_positions(body)
+    if len(positions) <= 1:
+        return [line]
+    indent = body[: len(body) - len(body.lstrip())]
+    out = []
+    prefix = body[: positions[0]].rstrip()
+    if prefix.strip():
+        out.append(prefix)
+    for k, p in enumerate(positions):
+        end = positions[k + 1] if k + 1 < len(positions) else len(body)
+        out.append(indent + body[p:end].rstrip())
+    return [s + "\n" for s in out]
+
+
+def file_is_affected(path: str) -> int:
+    """Return count of lines with >1 inline Annotations: (0 = clean)."""
+    n = 0
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if line.count("Annotations:") > 1 and len(annotation_keyword_positions(line)) > 1:
+                    n += 1
+    except Exception:
+        return 0
+    return n
+
+
+def normalize_file(path: str) -> int:
+    """Rewrite the file with inline Annotations: split. Returns lines changed."""
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        lines = f.readlines()
+    out, changed = [], 0
+    for line in lines:
+        pieces = split_line(line)
+        if len(pieces) > 1:
+            changed += 1
+        out.extend(pieces)
+    if changed:
+        if not os.path.exists(path + ".orig"):
+            os.replace(path, path + ".orig")
+        else:
+            os.remove(path)
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(out)
+    return changed
+
+
+def iter_owl(root: str):
+    for dirpath, _, files in os.walk(root):
+        for fn in files:
+            if fn.endswith(".owl"):
+                yield os.path.join(dirpath, fn)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("paths", nargs="+", help="ontology root dir(s) and/or .owl files")
+    ap.add_argument("--scan", action="store_true", help="report affected files, write nothing")
+    ap.add_argument("--apply", action="store_true", help="rewrite affected files (backs up .orig)")
+    args = ap.parse_args()
+    if not args.scan and not args.apply:
+        ap.error("pass --scan or --apply")
+
+    targets: list[str] = []
+    for p in args.paths:
+        if os.path.isdir(p):
+            targets.extend(iter_owl(p))
+        else:
+            targets.append(p)
+
+    affected = []
+    for path in targets:
+        n = file_is_affected(path)
+        if n:
+            affected.append((path, n))
+
+    print(f"Scanned {len(targets)} files; {len(affected)} affected.")
+    for path, n in affected:
+        print(f"  {n:4d} bad lines  {path}")
+
+    if args.apply:
+        print()
+        for path, _ in affected:
+            c = normalize_file(path)
+            print(f"  fixed {c} lines in {path} (backup {path}.orig)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_distribution.py
+++ b/scripts/plan_distribution.py
@@ -256,13 +256,32 @@ def fetch_current_memory_limits(ssh_host: str) -> dict[int, int]:
     return out
 
 
+# Ontologies whose true memory footprint is far larger than their class count
+# implies: ABox/individual-heavy datasets that are huge FILES with very few
+# classes (ISO-15926 reference data, authority/registry lists). Class-count
+# bucketing places them in small (xs/s) workers where they OOM — rdl alone needs
+# ~10 GB. They are pinned to a dedicated fixed-size worker instead.
+# Measured 2026-06-08: these 6 = 30 GB live combined -> a 48 GB / -Xmx40g worker
+# (deployed as physical aberowl-worker-37). See worker_measurements ledger.
+PINNED_GIANTS = {
+    "rdl", "lcgft", "ror", "fast-title", "xref-funder-reg", "nlmvs",
+}
+PINNED_GIANTS_MEMORY_GB = 48
+
+
 def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]) -> list[WorkerSlot]:
     """Greedy bin-pack ontologies into workers respecting bucket rules.
 
     Iterates over buckets xl → xs, assigning ontologies (largest first within
     each bucket) to workers. xl gets a dedicated worker. Others fill workers
-    up to the bucket's max_per_worker and class_budget.
+    up to the bucket's max_per_worker and class_budget. PINNED_GIANTS are pulled
+    out first onto a dedicated, fixed-size worker.
     """
+    # Pin ABox-heavy giants onto a dedicated worker; class-count bucketing would
+    # mis-size them into small workers where they OOM.
+    pinned = [r for r in records if (r.get("id") or "").lower() in PINNED_GIANTS]
+    records = [r for r in records if (r.get("id") or "").lower() not in PINNED_GIANTS]
+
     # Group records by bucket, drop entries with no classes data
     by_bucket: dict[str, list[dict]] = defaultdict(list)
     skipped = []
@@ -315,6 +334,12 @@ def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]
                 s.ontologies.append(cand)
                 i += 1
             finalize_mem(s)
+
+    # Dedicated worker for the pinned giants: fixed measured size, not the
+    # class-count model (which under-sizes ABox-heavy data).
+    if pinned:
+        g = new_slot("giants", PINNED_GIANTS_MEMORY_GB)
+        g.ontologies.extend(pinned)
 
     return slots
 

--- a/scripts/plan_distribution.py
+++ b/scripts/plan_distribution.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python3
+"""Plan a balanced ontology-to-worker distribution using class-count metrics.
+
+Pulls the same data as fleet_report.py (aberowl + BioPortal fill-in), then
+bin-packs ontologies into workers using a class-count-based memory model
+calibrated against what we've observed empirically (biomodels at 187k
+classes OOM'd at 16 GB; ncbitaxon at 2.7M needs 96 GB; etc.).
+
+Outputs:
+  - results/plan_distribution_<date>.json — machine-readable plan
+    [{worker_n, memory_gb, ontologies: [{id, path, reasoner, classes}]}, ...]
+  - results/plan_distribution_<date>.html — side-by-side current vs proposed
+
+Does NOT apply changes. Apply manually via deploy/launch_workers.py or
+by writing the worker_N_config.json files and restarting containers.
+
+Usage:
+    python3 scripts/plan_distribution.py
+    python3 scripts/plan_distribution.py --preserve-memory
+    python3 scripts/plan_distribution.py --no-current   # don't ssh for current configs
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import math
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import requests
+
+# Reuse the data layer from fleet_report
+sys.path.insert(0, str(Path(__file__).parent))
+from fleet_report import (  # noqa: E402
+    fetch_servers, gather, DEFAULT_CENTRAL, DEFAULT_BP_APIKEY, DEFAULT_CACHE,
+)
+
+DEFAULT_OUTPUT_HTML = Path(f"results/plan_distribution_{dt.date.today().isoformat()}.html")
+DEFAULT_OUTPUT_JSON = Path(f"results/plan_distribution_{dt.date.today().isoformat()}.json")
+DEFAULT_SSH_HOST = "onto"
+N_WORKERS = 33
+
+# Memory model calibrated to observations:
+#   - biomodels 187k classes OOM'd at 16 GB → need at least 24 GB
+#   - FMA 105k structural reasoner, 24 GB → fine
+#   - ncbitaxon 2.7M, 96 GB → fine
+#   - small ontologies (< 1k classes) → 1-2 GB each, but JVM overhead is ~4 GB minimum
+def estimate_solo_memory_gb(classes: int | None, dl_expr: str | None) -> int:
+    """Estimated heap need (in GB) for one ontology classified with ELK alone.
+
+    Tightened to match observations: biomodels @ 187k needed 24G; CHEBI @ 224k
+    fit in 16G (tight); MONDO @ 58k fit in 32G with headroom; ncbitaxon @ 2.7M
+    fits in 96G. Strategy: start lean, bump on OOM during deployment.
+    """
+    n = classes or 1
+    if n < 1_000:
+        base = 4
+    elif n < 10_000:
+        base = 6
+    elif n < 50_000:
+        base = 8
+    elif n < 150_000:
+        base = 12
+    elif n < 300_000:
+        base = 20
+    elif n < 500_000:
+        base = 24
+    elif n < 1_000_000:
+        base = 32
+    elif n < 3_000_000:
+        base = 64
+    else:
+        base = 96
+    # Non-EL profiles can blow ELK up — modest bump
+    if dl_expr and not all(c in "EL+" for c in dl_expr):
+        base = math.ceil(base * 1.3)
+    return base
+
+
+# Shared JVM/process overhead (GB). One worker = one JVM; ontologies on the
+# same worker share this floor.
+JVM_BASE_GB = 4
+
+# Marginal heap (GB) each *additional* co-located ontology adds, per 1000 of
+# its classes. The dominant ontology drives the reasoning peak (its full solo
+# estimate); every other ontology's marginal cost is ~proportional to its size,
+# NOT its padded solo estimate (a small ontology's solo is mostly the shared
+# JVM floor, so summing solo-minus-floor across many tiny ontologies invents
+# tens of GB that the live fleet never uses). Fit against uncapped multi-
+# ontology workers — incl. worker-10 (29 ontologies / 45k classes in 7.9 GB)
+# and worker-14 (24 ontologies in 6.5 GB): 0.10 covers every observed worker
+# without under-provisioning, while keeping many-small workers near their JVM
+# floor.
+MARGINAL_GB_PER_1K_CLASSES = 0.10
+
+
+def estimate_worker_memory_gb(ontologies: list[dict]) -> int:
+    """Heap need for a worker hosting one or many ontologies in one JVM.
+
+    mem = solo(dominant) + marginal-per-class * (classes of all other
+    ontologies). The dominant (largest) ontology sets the reasoning peak; the
+    rest add a size-proportional marginal cost. Never drops below the dominant
+    ontology's solo estimate. Replaces the old model that sized from the
+    dominant ontology only and under-provisioned co-located large reasoners.
+    """
+    if not ontologies:
+        return JVM_BASE_GB
+    solos = {id(o): estimate_solo_memory_gb(o.get("classes"), o.get("dl_expressivity"))
+             for o in ontologies}
+    dominant = max(ontologies, key=lambda o: solos[id(o)])
+    mem = solos[id(dominant)]
+    for o in ontologies:
+        if o is dominant:
+            continue
+        # Marginal cost scales with size, but never exceeds what this ontology
+        # would need standalone above the shared JVM floor (a second large
+        # reasoner can't cost more co-located than it would alone).
+        marginal = min(MARGINAL_GB_PER_1K_CLASSES * (o.get("classes") or 0) / 1000,
+                       solos[id(o)] - JVM_BASE_GB)
+        mem += max(0.0, marginal)
+    return max(int(math.ceil(mem)), solos[id(dominant)])
+
+
+# Bucket assignment rules: (name, min_classes, max_classes, max_per_worker, class_budget)
+BUCKETS = [
+    ("xl",   500_000,  float("inf"),  1,        float("inf")),
+    ("l",    100_000,  500_000,       2,        800_000),
+    ("m",     10_000,  100_000,       10,       300_000),
+    ("s",      1_000,   10_000,       40,       100_000),
+    ("xs",         0,    1_000,      150,        50_000),
+]
+
+
+def class_bucket(n: int | None) -> str:
+    n = n or 0
+    for name, lo, hi, _, _ in BUCKETS:
+        if lo <= n < hi:
+            return name
+    return "xs"
+
+
+@dataclass
+class WorkerSlot:
+    n: int
+    bucket: str = ""
+    ontologies: list[dict] = field(default_factory=list)
+    memory_gb: int = 12
+
+    @property
+    def total_classes(self) -> int:
+        return sum((o.get("classes") or 0) for o in self.ontologies)
+
+    @property
+    def total_individuals(self) -> int:
+        return sum((o.get("individuals") or 0) for o in self.ontologies)
+
+
+def fetch_current_configs(ssh_host: str) -> dict[int, list[dict]]:
+    """SSH to onto and read every worker_N_config.json. Empty dict on failure.
+
+    Returns plain shell-tarred bundle: prints each file with a marker line
+    we can parse client-side. Avoids inline-python-over-ssh quoting hell.
+    """
+    out: dict[int, list[dict]] = {}
+    try:
+        # Emit each config file prefixed by "==== worker_N_config.json ===="
+        cmd = (
+            "for f in /data/aberowl/ontologies/worker_*_config.json; do "
+            "  [ -f \"$f\" ] || continue; "
+            "  echo \"==== $(basename $f) ====\"; "
+            "  sudo -n cat \"$f\"; "
+            "  echo; "
+            "done"
+        )
+        r = subprocess.run(
+            ["ssh", ssh_host, cmd],
+            capture_output=True, text=True, timeout=60, check=True,
+        )
+        # Parse blocks
+        current_name: str | None = None
+        current_lines: list[str] = []
+        def flush() -> None:
+            if current_name is None:
+                return
+            try:
+                n = int(current_name.split("_")[1])
+            except (IndexError, ValueError):
+                return
+            body = "\n".join(current_lines).strip()
+            if not body:
+                out[n] = []
+                return
+            try:
+                out[n] = json.loads(body)
+            except json.JSONDecodeError:
+                out[n] = []
+        for line in r.stdout.splitlines():
+            if line.startswith("==== ") and line.endswith(" ===="):
+                flush()
+                current_name = line.strip("= ").strip()
+                current_lines = []
+            else:
+                current_lines.append(line)
+        flush()
+    except Exception as e:
+        print(f"WARN: couldn't read current configs from {ssh_host}: {e}", file=sys.stderr)
+    return out
+
+
+def fetch_on_disk_ontologies(ssh_host: str, min_size: int = 20_000) -> set[str]:
+    """List ontology IDs that have an OWL file on disk on onto (>min_size bytes).
+
+    Looks at /data/aberowl/ontologies/<id>/<id>.owl. Returns set of ids.
+    """
+    out: set[str] = set()
+    try:
+        r = subprocess.run(
+            ["ssh", ssh_host,
+             f"sudo -n find /data/aberowl/ontologies -mindepth 2 -maxdepth 2 "
+             f"-name '*.owl' -type f -size +{min_size}c -printf '%f\\n'"],
+            capture_output=True, text=True, timeout=60, check=True,
+        )
+        for line in r.stdout.splitlines():
+            line = line.strip()
+            if line.endswith(".owl"):
+                out.add(line[:-4].lower())
+    except Exception as e:
+        print(f"WARN: couldn't list on-disk ontologies from {ssh_host}: {e}", file=sys.stderr)
+    return out
+
+
+def fetch_current_memory_limits(ssh_host: str) -> dict[int, int]:
+    """SSH to onto and read each worker's docker memory limit (in GB)."""
+    out: dict[int, int] = {}
+    try:
+        r = subprocess.run(
+            ["ssh", ssh_host,
+             "for n in $(seq 1 33); do "
+             "  m=$(sudo -n docker inspect aberowl-worker-$n --format '{{.HostConfig.Memory}}' 2>/dev/null); "
+             "  if [ -n \"$m\" ]; then echo \"$n $((m/1073741824))\"; fi; "
+             "done"],
+            capture_output=True, text=True, timeout=30, check=True,
+        )
+        for line in r.stdout.strip().splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                out[int(parts[0])] = int(parts[1])
+    except Exception as e:
+        print(f"WARN: couldn't read memory limits from {ssh_host}: {e}", file=sys.stderr)
+    return out
+
+
+def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]) -> list[WorkerSlot]:
+    """Greedy bin-pack ontologies into workers respecting bucket rules.
+
+    Iterates over buckets xl → xs, assigning ontologies (largest first within
+    each bucket) to workers. xl gets a dedicated worker. Others fill workers
+    up to the bucket's max_per_worker and class_budget.
+    """
+    # Group records by bucket, drop entries with no classes data
+    by_bucket: dict[str, list[dict]] = defaultdict(list)
+    skipped = []
+    for r in records:
+        if not r.get("classes"):
+            skipped.append(r["id"])
+            continue
+        by_bucket[class_bucket(r["classes"])].append(r)
+
+    # Sort each bucket largest first so big ones get placed earliest
+    for b in by_bucket.values():
+        b.sort(key=lambda o: -(o.get("classes") or 0))
+
+    slots: list[WorkerSlot] = []
+    next_worker_n = 1
+
+    def new_slot(bucket_name: str, memory_gb: int) -> WorkerSlot:
+        nonlocal next_worker_n
+        s = WorkerSlot(n=next_worker_n, bucket=bucket_name, memory_gb=memory_gb)
+        next_worker_n += 1
+        slots.append(s)
+        return s
+
+    def finalize_mem(s: WorkerSlot) -> None:
+        # Size memory from the full ontology set once packing is done — each
+        # reasoner needs its own working set on top of the shared JVM floor.
+        mem = estimate_worker_memory_gb(s.ontologies)
+        if preserve_memory:
+            mem = min(mem, current_mem.get(s.n, mem))
+        s.memory_gb = mem
+
+    # Plan xl first — each gets dedicated worker
+    for r in by_bucket.get("xl", []):
+        s = new_slot("xl", JVM_BASE_GB)
+        s.ontologies.append(r)
+        finalize_mem(s)
+
+    # Plan l, m, s, xs greedily
+    for bname, lo, hi, max_per, class_budget in BUCKETS:
+        if bname == "xl":
+            continue
+        bucket_list = by_bucket.get(bname, [])
+        i = 0
+        while i < len(bucket_list):
+            s = new_slot(bname, JVM_BASE_GB)
+            while i < len(bucket_list) and len(s.ontologies) < max_per:
+                cand = bucket_list[i]
+                if s.ontologies and s.total_classes + (cand.get("classes") or 0) > class_budget:
+                    break
+                s.ontologies.append(cand)
+                i += 1
+            finalize_mem(s)
+
+    return slots
+
+
+def render_html(slots: list[WorkerSlot], current_cfg: dict[int, list[dict]],
+                current_mem: dict[int, int], base_url: str, total_servers: int) -> str:
+    today = dt.date.today().isoformat()
+
+    def fnum(n):
+        return f"{n:,}" if (n is not None and n != 0) else "—"
+
+    # Build "current" view keyed by worker_n
+    current_view = []
+    for n in sorted(current_cfg.keys()):
+        ids = [c["id"] for c in current_cfg[n]]
+        current_view.append({
+            "n": n,
+            "mem_gb": current_mem.get(n, "?"),
+            "ids": ids,
+            "count": len(ids),
+        })
+
+    # Proposed view
+    proposed_view = []
+    for s in slots:
+        proposed_view.append({
+            "n": s.n,
+            "mem_gb": s.memory_gb,
+            "bucket": s.bucket,
+            "classes": s.total_classes,
+            "ids": [o["id"] for o in s.ontologies],
+            "count": len(s.ontologies),
+        })
+
+    # Per-worker diff: pair current[i] with proposed[i] for visual comparison
+    pair_count = max(len(current_view), len(proposed_view))
+
+    current_rows = []
+    for i in range(pair_count):
+        if i < len(current_view):
+            v = current_view[i]
+            id_list = ", ".join(v["ids"][:5]) + ("..." if len(v["ids"]) > 5 else "")
+            current_rows.append(
+                f"<tr><td>worker-{v['n']}</td><td>{v['mem_gb']}G</td>"
+                f"<td>{v['count']}</td><td class=ids>{html.escape(id_list)}</td></tr>"
+            )
+        else:
+            current_rows.append("<tr><td>—</td><td>—</td><td>—</td><td>—</td></tr>")
+
+    proposed_rows = []
+    for i in range(pair_count):
+        if i < len(proposed_view):
+            v = proposed_view[i]
+            id_list = ", ".join(v["ids"][:5]) + ("..." if len(v["ids"]) > 5 else "")
+            cur_mem = current_mem.get(v["n"])
+            mem_change = ""
+            if cur_mem and cur_mem != v["mem_gb"]:
+                arrow = "↑" if v["mem_gb"] > cur_mem else "↓"
+                mem_change = f" <span class=memchange>{arrow}{v['mem_gb']-cur_mem:+}G</span>"
+            proposed_rows.append(
+                f"<tr><td>worker-{v['n']} <span class=bucket_{v['bucket']}>{v['bucket']}</span></td>"
+                f"<td>{v['mem_gb']}G{mem_change}</td>"
+                f"<td>{v['count']}</td>"
+                f"<td>{fnum(v['classes'])}</td>"
+                f"<td class=ids>{html.escape(id_list)}</td></tr>"
+            )
+        else:
+            proposed_rows.append("<tr><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>")
+
+    # Memory delta summary
+    cur_total = sum(current_mem.values())
+    proposed_total = sum(s.memory_gb for s in slots)
+
+    return f"""<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>distribution plan {today}</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; margin: 20px; color: #222; }}
+  h1, h2 {{ color: #111; }}
+  .grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }}
+  table {{ border-collapse: collapse; font-size: 12px; width: 100%; }}
+  th, td {{ padding: 3px 6px; border-bottom: 1px solid #ddd; text-align: left; vertical-align: top; }}
+  th {{ background: #f4f4f4; }}
+  td.ids {{ max-width: 380px; word-break: break-word; color: #555; }}
+  .bucket_xl {{ background: #fdd; padding: 1px 4px; border-radius: 3px; font-size: 11px; }}
+  .bucket_l  {{ background: #fed; padding: 1px 4px; border-radius: 3px; font-size: 11px; }}
+  .bucket_m  {{ background: #ffd; padding: 1px 4px; border-radius: 3px; font-size: 11px; }}
+  .bucket_s  {{ background: #dfd; padding: 1px 4px; border-radius: 3px; font-size: 11px; }}
+  .bucket_xs {{ background: #ddf; padding: 1px 4px; border-radius: 3px; font-size: 11px; }}
+  .memchange {{ color: #c33; font-weight: bold; }}
+  .note {{ background: #fffae6; border-left: 3px solid #f7b733; padding: 8px; margin: 10px 0; }}
+</style>
+</head><body>
+<h1>aberowl2 distribution plan</h1>
+<p><b>Source data:</b> {html.escape(base_url)} &middot;
+   <b>Generated:</b> {dt.datetime.now().isoformat(timespec='seconds')} &middot;
+   <b>Total ontologies:</b> {total_servers}</p>
+<p><b>Workers in plan:</b> {len(slots)} (max {N_WORKERS}) &middot;
+   <b>Memory budget current vs proposed:</b> {cur_total}G → {proposed_total}G
+   ({proposed_total - cur_total:+}G)</p>
+
+<div class=note>
+This is a <b>proposal</b>, not applied. To apply: write each worker_N_config.json,
+adjust memory limits where indicated (docker rm + docker run), then restart each
+worker one at a time.
+</div>
+
+<div class=grid>
+  <div>
+    <h2>Current distribution</h2>
+    <table>
+    <thead><tr><th>worker</th><th>memory</th><th>count</th><th>ontologies</th></tr></thead>
+    <tbody>{''.join(current_rows)}</tbody>
+    </table>
+  </div>
+  <div>
+    <h2>Proposed distribution</h2>
+    <table>
+    <thead><tr><th>worker</th><th>memory</th><th>count</th><th>classes</th><th>ontologies</th></tr></thead>
+    <tbody>{''.join(proposed_rows)}</tbody>
+    </table>
+  </div>
+</div>
+
+</body></html>"""
+
+
+def match_plan_to_current(slots: list[WorkerSlot], current_cfg: dict[int, list[dict]]) -> dict[int, int | None]:
+    """Greedy match plan worker → existing worker by ontology-ID overlap.
+
+    Walks plan slots in size order (largest first), and for each finds the
+    unmatched current worker whose ontology set has the most IDs in common.
+    Returns {plan_worker_n: matched_existing_worker_n or None}.
+    """
+    current_sets = {n: set(c["id"] for c in cfg) for n, cfg in current_cfg.items()}
+    available = set(current_sets.keys())
+    mapping: dict[int, int | None] = {}
+
+    # Sort plan slots largest first
+    sorted_slots = sorted(slots, key=lambda s: -s.total_classes)
+    for s in sorted_slots:
+        plan_ids = {o["id"] for o in s.ontologies}
+        best_n, best_overlap = None, -1
+        for cur_n in available:
+            ovl = len(plan_ids & current_sets[cur_n])
+            if ovl > best_overlap:
+                best_n, best_overlap = cur_n, ovl
+        # Only claim a current worker if there's at least one ontology in common
+        if best_overlap > 0 and best_n is not None:
+            mapping[s.n] = best_n
+            available.discard(best_n)
+        else:
+            mapping[s.n] = None  # plan worker is "new"
+    return mapping
+
+
+def compute_diff(slots: list[WorkerSlot], current_cfg: dict[int, list[dict]],
+                 current_mem: dict[int, int]) -> dict:
+    """Compute per-worker diff between plan and current."""
+    mapping = match_plan_to_current(slots, current_cfg)
+    matched_current = {cur_n for cur_n in mapping.values() if cur_n is not None}
+
+    matched, new, memory_changed, unchanged = [], [], [], []
+    for s in slots:
+        cur_n = mapping[s.n]
+        plan_ids = {o["id"] for o in s.ontologies}
+        if cur_n is None:
+            new.append({
+                "plan_n": s.n,
+                "memory_gb": s.memory_gb,
+                "bucket": s.bucket,
+                "add": sorted(plan_ids),
+            })
+            continue
+        cur_ids = {c["id"] for c in current_cfg.get(cur_n, [])}
+        add = sorted(plan_ids - cur_ids)
+        remove = sorted(cur_ids - plan_ids)
+        cur_mem = current_mem.get(cur_n)
+        mem_changed = cur_mem is not None and cur_mem != s.memory_gb
+        rec = {
+            "plan_n": s.n, "current_n": cur_n,
+            "current_mem_gb": cur_mem, "planned_mem_gb": s.memory_gb,
+            "bucket": s.bucket,
+            "add": add, "remove": remove,
+            "memory_changed": mem_changed,
+        }
+        if not add and not remove and not mem_changed:
+            unchanged.append(rec)
+        else:
+            (memory_changed if mem_changed and not add and not remove else matched).append(rec)
+
+    retired = [
+        {"current_n": cur_n,
+         "current_mem_gb": current_mem.get(cur_n),
+         "remove": sorted(c["id"] for c in cfg)}
+        for cur_n, cfg in current_cfg.items()
+        if cur_n not in matched_current
+    ]
+    return {
+        "unchanged": unchanged,
+        "matched": matched,
+        "memory_only": memory_changed,
+        "new_workers": new,
+        "retired_workers": retired,
+    }
+
+
+def render_diff_html(diff: dict, base_url: str) -> str:
+    """Render the diff as a dedicated HTML page showing only what changes."""
+    today = dt.date.today().isoformat()
+
+    def chips(ids: list[str], cls: str) -> str:
+        return " ".join(f'<span class="chip {cls}">{html.escape(i)}</span>' for i in ids)
+
+    def mem_arrow(cur: int | None, plan: int) -> str:
+        if cur is None or cur == plan:
+            return f"<span class=mem>{plan}G</span>"
+        delta = plan - cur
+        cls = "memup" if delta > 0 else "memdown"
+        return (f"<span class=mem>{cur}G &rarr; {plan}G "
+                f"<span class='{cls}'>({delta:+}G)</span></span>")
+
+    # Modified workers
+    mod_rows = []
+    for r in sorted(diff["matched"], key=lambda x: x["current_n"]):
+        mem_html = mem_arrow(r["current_mem_gb"], r["planned_mem_gb"])
+        mod_rows.append(f"""
+        <tr>
+          <td><b>worker-{r['current_n']}</b> <span class=bucket_{r['bucket']}>{r['bucket']}</span></td>
+          <td>{mem_html}</td>
+          <td class=count>+{len(r['add'])}</td><td>{chips(r['add'], 'add')}</td>
+          <td class=count>-{len(r['remove'])}</td><td>{chips(r['remove'], 'rem')}</td>
+        </tr>""")
+
+    # Memory-only changes
+    mem_rows = []
+    for r in sorted(diff["memory_only"], key=lambda x: x["current_n"]):
+        mem_rows.append(
+            f"<tr><td><b>worker-{r['current_n']}</b></td>"
+            f"<td>{mem_arrow(r['current_mem_gb'], r['planned_mem_gb'])}</td></tr>"
+        )
+
+    # New workers
+    new_rows = []
+    for r in sorted(diff["new_workers"], key=lambda x: x["plan_n"]):
+        new_rows.append(f"""
+        <tr>
+          <td><b>plan worker-{r['plan_n']}</b> <span class=bucket_{r['bucket']}>{r['bucket']}</span></td>
+          <td><span class=mem>{r['memory_gb']}G</span></td>
+          <td class=count>+{len(r['add'])}</td><td>{chips(r['add'], 'add')}</td>
+        </tr>""")
+
+    # Retired workers
+    retired_rows = []
+    for r in sorted(diff["retired_workers"], key=lambda x: x["current_n"]):
+        retired_rows.append(f"""
+        <tr>
+          <td><b>worker-{r['current_n']}</b></td>
+          <td><span class=mem>{r['current_mem_gb']}G</span></td>
+          <td class=count>-{len(r['remove'])}</td><td>{chips(r['remove'], 'rem')}</td>
+        </tr>""")
+
+    summary = (
+        f"<b>unchanged:</b> {len(diff['unchanged'])} &middot; "
+        f"<b>modified:</b> {len(diff['matched'])} &middot; "
+        f"<b>memory-only:</b> {len(diff['memory_only'])} &middot; "
+        f"<b>new:</b> {len(diff['new_workers'])} &middot; "
+        f"<b>retired:</b> {len(diff['retired_workers'])}"
+    )
+
+    return f"""<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>distribution plan diff {today}</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; margin: 20px; color: #222; }}
+  h1, h2 {{ color: #111; }}
+  h2 {{ margin-top: 30px; border-bottom: 2px solid #eee; padding-bottom: 4px; }}
+  table {{ border-collapse: collapse; font-size: 13px; width: 100%; margin-top: 8px; }}
+  th, td {{ padding: 6px 8px; border-bottom: 1px solid #e8e8e8; text-align: left; vertical-align: top; }}
+  th {{ background: #f4f4f4; }}
+  td.count {{ text-align: right; font-variant-numeric: tabular-nums;
+              white-space: nowrap; color: #555; }}
+  .chip {{ display: inline-block; padding: 1px 6px; margin: 1px;
+           border-radius: 3px; font-size: 11px;
+           font-family: ui-monospace, monospace; }}
+  .chip.add {{ background: #e0f5e0; color: #060; border: 1px solid #c2e0c2; }}
+  .chip.rem {{ background: #ffe5e5; color: #800; border: 1px solid #f0c0c0; }}
+  .mem {{ font-family: ui-monospace, monospace; font-size: 12px; white-space: nowrap; }}
+  .memup {{ color: #c33; font-weight: bold; }}
+  .memdown {{ color: #060; font-weight: bold; }}
+  .bucket_xl {{ background: #fdd; padding: 1px 5px; border-radius: 3px; font-size: 11px; }}
+  .bucket_l  {{ background: #fed; padding: 1px 5px; border-radius: 3px; font-size: 11px; }}
+  .bucket_m  {{ background: #ffd; padding: 1px 5px; border-radius: 3px; font-size: 11px; }}
+  .bucket_s  {{ background: #dfd; padding: 1px 5px; border-radius: 3px; font-size: 11px; }}
+  .bucket_xs {{ background: #ddf; padding: 1px 5px; border-radius: 3px; font-size: 11px; }}
+  .summary {{ background: #f8f8f8; padding: 10px; border-radius: 4px; margin: 10px 0; }}
+  .empty {{ color: #999; font-style: italic; }}
+</style>
+</head><body>
+<h1>distribution plan diff</h1>
+<p><b>Source:</b> {html.escape(base_url)} &middot;
+   <b>Generated:</b> {dt.datetime.now().isoformat(timespec='seconds')}</p>
+<div class=summary>{summary}</div>
+
+<h2>Modified workers ({len(diff['matched'])})</h2>
+{('<table><thead><tr><th>worker</th><th>memory</th><th>add</th><th>added ontologies</th><th>remove</th><th>removed ontologies</th></tr></thead><tbody>' + ''.join(mod_rows) + '</tbody></table>') if mod_rows else '<p class=empty>None.</p>'}
+
+<h2>Memory-only changes ({len(diff['memory_only'])})</h2>
+{('<table><thead><tr><th>worker</th><th>memory change</th></tr></thead><tbody>' + ''.join(mem_rows) + '</tbody></table>') if mem_rows else '<p class=empty>None.</p>'}
+
+<h2>New workers to launch ({len(diff['new_workers'])})</h2>
+{('<table><thead><tr><th>plan worker</th><th>memory</th><th>ontologies</th><th></th></tr></thead><tbody>' + ''.join(new_rows) + '</tbody></table>') if new_rows else '<p class=empty>None.</p>'}
+
+<h2>Workers to retire ({len(diff['retired_workers'])})</h2>
+{('<table><thead><tr><th>worker</th><th>current memory</th><th>removed</th><th>previously hosted</th></tr></thead><tbody>' + ''.join(retired_rows) + '</tbody></table>') if retired_rows else '<p class=empty>None.</p>'}
+
+</body></html>"""
+
+
+def print_diff(diff: dict) -> None:
+    print(f"=== Diff summary ===")
+    print(f"  unchanged:       {len(diff['unchanged'])} workers")
+    print(f"  modified:        {len(diff['matched'])} workers")
+    print(f"  memory-only:     {len(diff['memory_only'])} workers")
+    print(f"  new in plan:     {len(diff['new_workers'])} workers")
+    print(f"  retired:         {len(diff['retired_workers'])} workers")
+
+    if diff["matched"]:
+        print("\n--- modified workers (add/remove ontologies) ---")
+        for r in sorted(diff["matched"], key=lambda x: x["current_n"]):
+            tag = f" [{r['bucket']}]"
+            mem = ""
+            if r["memory_changed"]:
+                mem = f" mem={r['current_mem_gb']}G→{r['planned_mem_gb']}G"
+            print(f"  worker-{r['current_n']}{tag}{mem}  +{len(r['add'])} -{len(r['remove'])}")
+            if r["add"]:
+                print(f"    + {', '.join(r['add'][:10])}{'...' if len(r['add'])>10 else ''}")
+            if r["remove"]:
+                print(f"    - {', '.join(r['remove'][:10])}{'...' if len(r['remove'])>10 else ''}")
+
+    if diff["memory_only"]:
+        print("\n--- memory-only changes ---")
+        for r in sorted(diff["memory_only"], key=lambda x: x["current_n"]):
+            print(f"  worker-{r['current_n']}  {r['current_mem_gb']}G → {r['planned_mem_gb']}G")
+
+    if diff["new_workers"]:
+        print(f"\n--- new workers to launch ({len(diff['new_workers'])}) ---")
+        for r in diff["new_workers"]:
+            print(f"  plan worker-{r['plan_n']} [{r['bucket']}]  mem={r['memory_gb']}G  "
+                  f"adds {len(r['add'])} ontologies")
+            print(f"    + {', '.join(r['add'][:10])}{'...' if len(r['add'])>10 else ''}")
+
+    if diff["retired_workers"]:
+        print(f"\n--- workers to retire ({len(diff['retired_workers'])}) ---")
+        for r in diff["retired_workers"]:
+            print(f"  worker-{r['current_n']} (was {r['current_mem_gb']}G, "
+                  f"held {len(r['remove'])} ontologies)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default=DEFAULT_CENTRAL)
+    ap.add_argument("--bioportal-apikey", default=os.environ.get("BIOPORTAL_APIKEY", DEFAULT_BP_APIKEY))
+    ap.add_argument("--cache", type=Path, default=DEFAULT_CACHE)
+    ap.add_argument("--ssh-host", default=DEFAULT_SSH_HOST,
+                    help="ssh alias to read current configs/memory from")
+    ap.add_argument("--no-current", action="store_true",
+                    help="don't ssh; plan from scratch without current-state diff")
+    ap.add_argument("--preserve-memory", action="store_true",
+                    help="cap each worker's plan to its current memory limit")
+    ap.add_argument("--no-bioportal", action="store_true")
+    ap.add_argument("--out-html", type=Path, default=DEFAULT_OUTPUT_HTML)
+    ap.add_argument("--out-json", type=Path, default=DEFAULT_OUTPUT_JSON)
+    ap.add_argument("--diff", action="store_true",
+                    help="emit a CLI diff of plan vs current state (implies reading current)")
+    ap.add_argument("--diff-json", type=Path,
+                    help="also write diff to JSON at this path")
+    ap.add_argument("--diff-html", type=Path,
+                    help="also write diff to a focused HTML page (changes-only view)")
+    ap.add_argument("--include-missing", action="store_true",
+                    help="include ontologies that have no OWL file on disk (default: skip)")
+    ap.add_argument("--missing-md", type=Path,
+                    default=Path(f"results/missing_ontologies_{dt.date.today().isoformat()}.md"),
+                    help="write a markdown list of skipped ontologies (off-disk) here")
+    args = ap.parse_args()
+
+    print(f"Fetching /api/servers from {args.url}...", flush=True)
+    servers = fetch_servers(args.url)
+    records = gather(servers, args.bioportal_apikey, args.cache, not args.no_bioportal)
+    print(f"  {len(records)} ontologies, "
+          f"{sum(1 for r in records if r['source']!='unknown')} with metadata", flush=True)
+
+    current_cfg, current_mem, on_disk = {}, {}, set()
+    if not args.no_current:
+        print(f"Reading current configs + memory from {args.ssh_host}...", flush=True)
+        current_cfg = fetch_current_configs(args.ssh_host)
+        current_mem = fetch_current_memory_limits(args.ssh_host)
+        print(f"  {len(current_cfg)} configs, {len(current_mem)} memory limits", flush=True)
+        if not args.include_missing:
+            print(f"Reading on-disk ontology list from {args.ssh_host}...", flush=True)
+            on_disk = fetch_on_disk_ontologies(args.ssh_host)
+            print(f"  {len(on_disk)} ontologies have an OWL file on disk", flush=True)
+            # Fail loud: if the disk listing came back empty we cannot trust the
+            # plan (every ontology would silently pass the filter and we'd plan
+            # undeployable zombies). Require --include-missing to opt out.
+            if not on_disk:
+                print("ERROR: on-disk ontology list is empty (ssh/find failed?). "
+                      "Refusing to plan without disk verification. "
+                      "Pass --include-missing to override.", file=sys.stderr)
+                return 1
+
+    # Filter records to only on-disk ontologies, unless --include-missing
+    if on_disk:
+        skipped = [r for r in records if (r["id"] or "").lower() not in on_disk]
+        records = [r for r in records if (r["id"] or "").lower() in on_disk]
+        print(f"  skipping {len(skipped)} ontologies without OWL files on disk", flush=True)
+        # Write a markdown summary of the skipped set
+        args.missing_md.parent.mkdir(parents=True, exist_ok=True)
+        skipped_sorted = sorted(skipped, key=lambda r: r["id"] or "")
+        # Group by likely reason: license-gated set documented in deploy/README.md
+        LICENSE_GATED = {"meddra", "snomedct", "icd10", "icnp", "icpc2p", "hero",
+                         "mddb", "nddf", "ndfrt", "rcd", "who-art"}
+        gated = [r for r in skipped_sorted if (r["id"] or "").lower() in LICENSE_GATED]
+        other = [r for r in skipped_sorted if (r["id"] or "").lower() not in LICENSE_GATED]
+        md_lines = [
+            f"# Ontologies missing from disk (as of {dt.date.today().isoformat()})",
+            "",
+            f"Of {len(skipped) + len(records)} registered ontologies, {len(skipped)} have no",
+            "usable OWL file on disk under `/data/aberowl/ontologies/<id>/<id>.owl`.",
+            "These are excluded from the current distribution plan.",
+            "",
+            "## Likely causes",
+            "",
+            "Per the deploy README's bulk-onboarding section, BioPortal returns:",
+            "- ~65 `404 no_latest_submission` (abandoned submissions, nothing to download)",
+            "- ~11 `403 license_restricted` (requires manual approval at bioontology.org)",
+            "- Rest: parse errors, network blips, content issues",
+            "",
+            f"## License-gated ({len(gated)})",
+            "",
+            "These require per-account approval at bioontology.org before download:",
+            "",
+        ]
+        for r in gated:
+            md_lines.append(f"- `{r['id']}` ({r.get('title','')})")
+        md_lines += [
+            "",
+            f"## Other missing ({len(other)})",
+            "",
+            "Generally abandoned BP submissions, broken OBO purls, or parse failures.",
+            "Re-attempt by running `deploy/download_bioportal.py` or per-ontology curl.",
+            "",
+        ]
+        for r in other:
+            md_lines.append(f"- `{r['id']}` ({r.get('title','')})")
+        args.missing_md.write_text("\n".join(md_lines))
+        print(f"  wrote {args.missing_md}", flush=True)
+
+    slots = plan(records, args.preserve_memory, current_mem)
+    print(f"Plan: {len(slots)} workers; "
+          f"buckets: {dict((b, sum(1 for s in slots if s.bucket==b)) for b in ['xl','l','m','s','xs'])}",
+          flush=True)
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(
+        [{"worker_n": s.n, "memory_gb": s.memory_gb, "bucket": s.bucket,
+          "ontologies": [{"id": o["id"], "path": f"/data/{o['id']}/{o['id']}.owl",
+                          "reasoner": "elk", "classes": o.get("classes")}
+                         for o in s.ontologies]}
+         for s in slots],
+        indent=2,
+    ))
+    args.out_html.parent.mkdir(parents=True, exist_ok=True)
+    args.out_html.write_text(render_html(slots, current_cfg, current_mem, args.url, len(servers)))
+
+    print(f"Wrote {args.out_json}", flush=True)
+    print(f"Wrote {args.out_html}", flush=True)
+
+    if args.diff or args.diff_json or args.diff_html:
+        if not current_cfg:
+            print("WARN: --diff needs current configs (don't pass --no-current)", file=sys.stderr)
+            return 1
+        diff = compute_diff(slots, current_cfg, current_mem)
+        if args.diff:
+            print()
+            print_diff(diff)
+        if args.diff_json:
+            args.diff_json.parent.mkdir(parents=True, exist_ok=True)
+            args.diff_json.write_text(json.dumps(diff, indent=2))
+            print(f"Wrote {args.diff_json}", flush=True)
+        if args.diff_html:
+            args.diff_html.parent.mkdir(parents=True, exist_ok=True)
+            args.diff_html.write_text(render_diff_html(diff, args.url))
+            print(f"Wrote {args.diff_html}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rebuild_lbucket.py
+++ b/scripts/rebuild_lbucket.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Rebuild L-bucket worker(s) IN PLACE on onto, correctly:
+
+- The config is rebuilt from the REGISTRY (the ontologies currently routed to
+  worker-N) — NOT the stale on-disk worker_N_config.json, which may still list
+  ontologies that have since been migrated to new workers (re-loading those
+  would create duplicates).
+- The reasoner for each ontology is taken from the stale config if present
+  (e.g. fma=structural), else elk.
+- Sizing is robust: launch GENEROUS (scaled by class count), let it FULLY load,
+  measure live heap, then recreate trimmed at 1.4x live. (Measuring the old
+  worker first is unreliable if it's crash-looping / under-sized.)
+- Host port = 9200+N (old 90NN ports conflict). No repoint (registry url
+  aberowl-worker-N:8080 is unchanged).
+
+    sudo -n python3 rebuild_lbucket.py 2 3 9 ...
+"""
+import json, math, os, re, subprocess, sys, time
+
+ONT = "/data/aberowl/ontologies"
+
+def sh(*a):
+    return subprocess.run(a, capture_output=True, text=True).stdout.strip()
+
+def registry():
+    raw = sh("docker", "exec", "deploy-redis-1", "redis-cli", "HVALS", "registered_servers")
+    keep, classes, reasoner = {}, {}, {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except Exception:
+            continue
+        m = re.search(r"worker-(\d+):", d.get("url") or "")
+        if not m:
+            continue
+        n = int(m.group(1))
+        keep.setdefault(n, []).append(d.get("ontology"))
+        classes[d.get("ontology")] = d.get("class_count") or 0
+    return keep, classes
+
+def stale_reasoner(n):
+    try:
+        return {o["id"]: o.get("reasoner", "elk") for o in json.load(open(f"{ONT}/worker_{n}_config.json"))}
+    except Exception:
+        return {}
+
+def launch(n, xmx, mem, port, secret):
+    sh("docker", "rm", "-f", f"aberowl-worker-{n}")
+    return subprocess.run([
+        "docker", "run", "-d", "--name", f"aberowl-worker-{n}", "--network", "aberowl-net",
+        "-e", f"CONTAINER_ID=worker-{n}", "-e", f"ABEROWL_SECRET_KEY={secret}",
+        "-e", "CENTRAL_ES_URL=http://deploy-elasticsearch-1:9200",
+        "-e", "ELASTICSEARCH_URL=http://deploy-elasticsearch-1:9200",
+        "-e", f"ONTOLOGY_PATH=/data/worker_{n}_config.json",
+        "-e", f"JAVA_OPTS=-Xmx{xmx}g -Xms2g",
+        "-v", f"{ONT}:/data:ro", "-v", "/data/aberowl/aberowlapi:/app/aberowlapi:ro",
+        "-v", "/data/aberowl/docker/scripts:/scripts:ro",
+        "-p", f"{port}:8080", f"--memory={mem}g", "--restart", "unless-stopped",
+        "--log-opt", "max-size=30m", "--log-opt", "max-file=3",
+        "aberowl-api", "python3", "/app/api_server.py", f"/data/worker_{n}_config.json",
+    ], capture_output=True, text=True)
+
+def wait_serving(port, want):
+    for _ in range(45):
+        time.sleep(12)
+        c = sh("bash", "-lc",
+               f'curl -s --max-time 8 "http://localhost:{port}/api/listLoadedOntologies.groovy" '
+               f'| python3 -c "import json,sys;print(len(json.load(sys.stdin)[\\"ontologies\\"]))" 2>/dev/null')
+        if c.isdigit() and int(c) >= want:
+            return int(c)
+    return int(c) if c.isdigit() else 0
+
+def live_gb(n):
+    pid = sh("docker", "exec", f"aberowl-worker-{n}", "bash", "-lc",
+             "pgrep -f OntologyServer.groovy | head -1")
+    if not pid:
+        return None
+    sh("docker", "exec", f"aberowl-worker-{n}", "jcmd", pid, "GC.run")
+    time.sleep(3)
+    out = sh("docker", "exec", f"aberowl-worker-{n}", "jcmd", pid, "GC.heap_info")
+    m = re.search(r"used (\d+)K", out)
+    return int(m.group(1)) / 1048576 if m else None
+
+def main():
+    secret = sh("bash", "-lc",
+                "grep -E '^ABEROWL_SECRET_KEY=' /data/aberowl/deploy/.env | head -1 | cut -d= -f2-")
+    keep, classes = registry()
+    for n in [int(x) for x in sys.argv[1:]]:
+        ids = sorted(keep.get(n, []))
+        if not ids:
+            print(f"worker-{n}: nothing routed here in registry — skip", flush=True); continue
+        rmap = stale_reasoner(n)
+        cfg = [{"id": i, "path": f"/data/{i}/{i}.owl", "reasoner": rmap.get(i, "elk")} for i in ids]
+        open(f"{ONT}/worker_{n}_config.json", "w").write(json.dumps(cfg, indent=2))
+        tot_cls = sum(classes.get(i, 0) for i in ids)
+        tot_mb = sum((os.path.getsize(f"{ONT}/{i}/{i}.owl") if os.path.exists(f"{ONT}/{i}/{i}.owl") else 0)
+                     for i in ids) / 1e6
+        port = 9200 + n
+        # Generous launch sized by class count AND file size (some big ontologies
+        # have class_count=0 in the registry, e.g. mesh/loinc/cco — file size
+        # catches those so we don't under-size and fail the load).
+        gxmx = min(96, max(12, math.ceil(tot_cls / 4000) + 8, math.ceil(tot_mb / 12) + 8))
+        print(f"worker-{n} {ids} ({tot_cls} cls): generous -Xmx{gxmx}g", flush=True)
+        if launch(n, gxmx, gxmx + 6, port, secret).returncode != 0:
+            print(f"  generous launch FAILED — skip", flush=True); continue
+        served = wait_serving(port, len(ids))
+        live = live_gb(n)
+        if live is None:
+            print(f"  served {served}/{len(ids)} but could not measure — leaving at generous {gxmx+6}G", flush=True); continue
+        xmx = max(2, math.ceil(1.4 * live)); mem = xmx + (4 if xmx >= 12 else 2)
+        print(f"  loaded {served}/{len(ids)}, live={live:.1f}G -> trim to {mem}G/-Xmx{xmx}g", flush=True)
+        launch(n, xmx, mem, port, secret)
+        served2 = wait_serving(port, len(ids))
+        oom = sh("bash", "-lc", f"docker logs aberowl-worker-{n} --since 6m 2>&1 | grep -c OutOfMemoryError")
+        rss = sh("bash", "-lc", f'docker stats --no-stream --format "{{{{.MemUsage}}}}" aberowl-worker-{n}')
+        print(f"  -> DONE served {served2}/{len(ids)}, {mem}G/-Xmx{xmx}g, RSS {rss}, OOM {oom}", flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repoint_ontology.py
+++ b/scripts/repoint_ontology.py
@@ -52,6 +52,7 @@ import argparse
 import json
 import subprocess
 import sys
+import time
 
 REGISTRY_KEY = "registered_servers"
 
@@ -112,7 +113,7 @@ def repoint(args) -> int:
     print(f"Target worker URL: {target}")
     print(f"Mode: {'APPLY (writing)' if args.apply else 'DRY-RUN (no writes)'}\n")
 
-    changed = skipped = missing = 0
+    changed = skipped = missing = failed = 0
     for ont in args.ontology:
         raw = redis_get(args, ont)
         if raw is None:
@@ -144,19 +145,37 @@ def repoint(args) -> int:
         print(f"REPOINT  {ont:30s} {old_url} -> {target}{status_note}")
 
         if args.apply:
-            redis_set(args, ont, json.dumps(entry))
-            # Read back to confirm the write landed.
-            verify_raw = redis_get(args, ont)
-            verify = json.loads(verify_raw) if verify_raw else {}
-            if verify.get("url") != target:
-                sys.exit(f"  VERIFY FAILED for {ont}: url is {verify.get('url')!r}, expected {target!r}")
-            if verify.get("secret_key") != entry.get("secret_key"):
-                sys.exit(f"  VERIFY FAILED for {ont}: secret_key changed!")
+            # The central server runs a periodic metadata-refresh that reads
+            # every entry and writes it back; if it reads the old URL just
+            # before our write and writes just after, it clobbers us. Re-read,
+            # re-apply, and retry until the write sticks (verified by read-back).
+            ok_write = False
+            for attempt in range(5):
+                redis_set(args, ont, json.dumps(entry))
+                verify = json.loads(redis_get(args, ont) or "{}")
+                if (verify.get("url") == target
+                        and verify.get("secret_key") == entry.get("secret_key")):
+                    ok_write = True
+                    break
+                time.sleep(2)
+                cur = redis_get(args, ont)
+                if cur:
+                    try:
+                        entry = json.loads(cur)
+                        entry["url"] = target
+                        if args.set_online:
+                            entry["status"] = "online"
+                    except json.JSONDecodeError:
+                        pass
+            if not ok_write:
+                print(f"  VERIFY FAILED for {ont} after retries: url={verify.get('url')!r} (central refresh race)")
+                failed += 1
+                continue
         changed += 1
 
     print()
     verb = "Repointed" if args.apply else "Would repoint"
-    print(f"{verb}: {changed}  Skipped/noop: {skipped}  Missing: {missing}")
+    print(f"{verb}: {changed}  Skipped/noop: {skipped}  Missing: {missing}  Failed: {failed}")
     if not args.apply and changed:
         print("\nRe-run with --apply to write these changes.")
     return 0

--- a/scripts/repoint_ontology.py
+++ b/scripts/repoint_ontology.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Re-point an ontology's central-registry entry to a different worker.
+
+WHY THIS EXISTS
+---------------
+The central registry is a Redis hash `registered_servers` on the central
+server: ontologyId -> {ontology, url, status, secret_key}. The dispatcher
+forwards each query to the worker URL stored here. When we move an ontology
+to a different worker, its data and this registry entry must change in
+lockstep, or queries route to the wrong (old) worker and fail.
+
+`/register` would do this, but every existing entry is protected by a
+secret_key that was issued at bulk-registration time and never saved
+(deploy/register_workers.py discards it). So re-POSTing /register without
+the key gets a 403. This tool edits the registry directly instead --
+we own the database -- changing ONLY the `url` field and preserving the
+existing secret_key and status.
+
+It talks to Redis via `docker exec <container> redis-cli`, so run it on the
+host where the central-redis container lives (onto). Reads use HGET; the
+single write per ontology uses `redis-cli -x HSET` with the JSON piped on
+stdin to avoid shell-quoting issues.
+
+SAFETY
+------
+- Dry-run by default. Nothing is written unless you pass --apply.
+- Only `url` (and optionally `status`) is changed. secret_key is preserved.
+- Refuses to touch an ontology that has no existing entry (use
+  deploy/register_workers.py for brand-new ids).
+- Prints a before -> after diff for every change.
+
+USAGE (on onto)
+---------------
+    # Read-only: inspect current entries
+    python3 scripts/repoint_ontology.py --sudo --inspect mesh icd10pcs
+
+    # Dry-run a move of mesh onto worker-16
+    python3 scripts/repoint_ontology.py --sudo --worker-n 16 --ontology mesh
+
+    # Actually apply it
+    python3 scripts/repoint_ontology.py --sudo --worker-n 16 --ontology mesh --apply
+
+    # Move several ids onto the same worker, mark them online
+    python3 scripts/repoint_ontology.py --sudo --worker-n 30 \
+        --ontology a --ontology b --ontology c --set-online --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+REGISTRY_KEY = "registered_servers"
+
+
+def docker_base(args) -> list[str]:
+    base = ["sudo"] if args.sudo else []
+    base += ["docker", "exec"]
+    return base
+
+
+def redis_get(args, field: str) -> str | None:
+    """HGET registered_servers <field>. Returns the raw value or None if absent."""
+    cmd = docker_base(args) + [args.redis_container, "redis-cli", "HGET", REGISTRY_KEY, field]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"redis HGET failed for {field!r}: {out.stderr.strip() or out.stdout.strip()}")
+    val = out.stdout.rstrip("\n")
+    return val if val else None
+
+
+def redis_set(args, field: str, value: str) -> None:
+    """HSET registered_servers <field> <value>, value piped on stdin via -x."""
+    cmd = docker_base(args) + ["-i", args.redis_container, "redis-cli", "-x", "HSET", REGISTRY_KEY, field]
+    out = subprocess.run(cmd, input=value, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"redis HSET failed for {field!r}: {out.stderr.strip() or out.stdout.strip()}")
+
+
+def worker_url(args) -> str:
+    # Dispatch rstrips the trailing slash (central main.py), so it is cosmetic,
+    # but every existing registry entry stores one -- match the convention.
+    if args.worker_url:
+        url = args.worker_url
+    else:
+        url = f"http://aberowl-worker-{args.worker_n}:8080"
+    return url if url.endswith("/") else url + "/"
+
+
+def inspect(args) -> int:
+    for ont in args.inspect:
+        raw = redis_get(args, ont)
+        if raw is None:
+            print(f"  {ont:30s} (no entry)")
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            print(f"  {ont:30s} <unparseable> {raw[:120]}")
+            continue
+        key = entry.get("secret_key")
+        key_note = "has-key" if key else "NO-KEY"
+        print(f"  {ont:30s} {entry.get('status','?'):8s} {entry.get('url','?'):40s} [{key_note}]")
+    return 0
+
+
+def repoint(args) -> int:
+    target = worker_url(args)
+    print(f"Target worker URL: {target}")
+    print(f"Mode: {'APPLY (writing)' if args.apply else 'DRY-RUN (no writes)'}\n")
+
+    changed = skipped = missing = 0
+    for ont in args.ontology:
+        raw = redis_get(args, ont)
+        if raw is None:
+            print(f"MISSING  {ont:30s} -- no registry entry; use deploy/register_workers.py for new ids")
+            missing += 1
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            print(f"BADJSON  {ont:30s} -- entry is not valid JSON; skipping: {raw[:80]}")
+            skipped += 1
+            continue
+
+        old_url = entry.get("url")
+        old_status = entry.get("status")
+        new_status = "online" if args.set_online else old_status
+
+        if old_url == target and old_status == new_status:
+            print(f"NOOP     {ont:30s} already at {target} (status {old_status})")
+            skipped += 1
+            continue
+
+        # Mutate only url and (optionally) status; preserve secret_key + everything else.
+        entry["url"] = target
+        if args.set_online:
+            entry["status"] = "online"
+
+        status_note = f" status {old_status}->{entry.get('status')}" if old_status != entry.get("status") else ""
+        print(f"REPOINT  {ont:30s} {old_url} -> {target}{status_note}")
+
+        if args.apply:
+            redis_set(args, ont, json.dumps(entry))
+            # Read back to confirm the write landed.
+            verify_raw = redis_get(args, ont)
+            verify = json.loads(verify_raw) if verify_raw else {}
+            if verify.get("url") != target:
+                sys.exit(f"  VERIFY FAILED for {ont}: url is {verify.get('url')!r}, expected {target!r}")
+            if verify.get("secret_key") != entry.get("secret_key"):
+                sys.exit(f"  VERIFY FAILED for {ont}: secret_key changed!")
+        changed += 1
+
+    print()
+    verb = "Repointed" if args.apply else "Would repoint"
+    print(f"{verb}: {changed}  Skipped/noop: {skipped}  Missing: {missing}")
+    if not args.apply and changed:
+        print("\nRe-run with --apply to write these changes.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Re-point ontology registry entries to a worker (direct Redis edit).")
+    ap.add_argument("--redis-container", default="aberowl-central-redis",
+                    help="Name of the central Redis container (default: aberowl-central-redis)")
+    ap.add_argument("--sudo", action="store_true", help="Prefix docker commands with sudo (needed on onto)")
+
+    ap.add_argument("--inspect", nargs="+", metavar="ID",
+                    help="Read-only: print current registry entries for these ontology ids and exit")
+
+    ap.add_argument("--ontology", action="append", default=[], metavar="ID",
+                    help="Ontology id to re-point (repeatable)")
+    grp = ap.add_mutually_exclusive_group()
+    grp.add_argument("--worker-n", type=int, help="Physical worker number; URL = http://aberowl-worker-N:8080")
+    grp.add_argument("--worker-url", help="Explicit worker URL (overrides --worker-n)")
+
+    ap.add_argument("--set-online", action="store_true",
+                    help="Also set status=online (default: preserve existing status)")
+    ap.add_argument("--apply", action="store_true", help="Actually write changes (default: dry-run)")
+
+    args = ap.parse_args()
+
+    if args.inspect:
+        return inspect(args)
+
+    if not args.ontology:
+        ap.error("provide --inspect ID..., or --ontology ID with --worker-n/--worker-url")
+    if args.worker_n is None and not args.worker_url:
+        ap.error("--ontology requires a target: --worker-n N or --worker-url URL")
+    return repoint(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seed_registry.py
+++ b/scripts/seed_registry.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Seed the central server registry with dummy ontology entries.
+
+Registers N fake ontologies (offline workers) so the registry has enough
+entries to make O(n) Redis scan overhead measurable in benchmarks.
+
+Usage:
+    python scripts/seed_registry.py --count 100          # add 100 dummy entries
+    python scripts/seed_registry.py --clear              # remove all dummy_* entries
+    python scripts/seed_registry.py --count 50 --url http://localhost:8000
+"""
+
+import argparse
+import sys
+import time
+import requests
+
+
+DUMMY_PREFIX = "dummy_bench_"
+
+
+def seed(base_url: str, count: int) -> None:
+    print(f"Seeding {count} dummy entries into {base_url} ...")
+    ok = 0
+    for i in range(count):
+        ont_id = f"{DUMMY_PREFIX}{i:04d}"
+        try:
+            r = requests.post(
+                f"{base_url}/register",
+                json={
+                    "ontology": ont_id,
+                    "url": f"http://dummy-worker-{i:04d}.invalid:9999",
+                },
+                timeout=5,
+            )
+            if r.status_code == 200:
+                ok += 1
+            else:
+                print(f"  WARN {ont_id}: HTTP {r.status_code}", file=sys.stderr)
+        except Exception as e:
+            print(f"  ERR {ont_id}: {e}", file=sys.stderr)
+        # Small delay so the server's async metadata fetches don't pile up
+        if i % 20 == 19:
+            time.sleep(0.5)
+
+    print(f"Done: {ok}/{count} registered.")
+    print("Note: entries will appear 'offline' (expected — workers are fake).")
+
+
+def clear(base_url: str) -> None:
+    """Remove all dummy_bench_* entries via the admin Redis flush endpoint,
+    falling back to individual deregistrations if that route doesn't exist."""
+    print(f"Fetching server list from {base_url} ...")
+    try:
+        r = requests.get(f"{base_url}/api/servers", timeout=10)
+        r.raise_for_status()
+        servers = r.json()
+    except Exception as e:
+        print(f"Failed to fetch server list: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    dummy = [s for s in servers if s.get("ontology", "").startswith(DUMMY_PREFIX)]
+    if not dummy:
+        print("No dummy entries found.")
+        return
+
+    print(f"Found {len(dummy)} dummy entries — removing via Redis CLI ...")
+    import subprocess
+    removed = 0
+    for s in dummy:
+        ont = s["ontology"]
+        result = subprocess.run(
+            ["docker", "exec", "aberowl-central-redis",
+             "redis-cli", "HDEL", "registered_servers", ont],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            removed += 1
+        else:
+            print(f"  WARN could not remove {ont}: {result.stderr.strip()}", file=sys.stderr)
+
+    print(f"Removed {removed}/{len(dummy)} dummy entries.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed/clear dummy registry entries.")
+    parser.add_argument("--url", default="http://localhost:8000", help="Central server base URL")
+    parser.add_argument("--count", type=int, default=100, help="Number of dummy entries to add")
+    parser.add_argument("--clear", action="store_true", help="Remove all dummy entries instead of adding")
+    args = parser.parse_args()
+
+    if args.clear:
+        clear(args.url)
+    else:
+        seed(args.url, args.count)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/aberowlapi/test_dl_query_bugs.py
+++ b/tests/aberowlapi/test_dl_query_bugs.py
@@ -1,0 +1,242 @@
+"""Regression tests for two DL-query parser bugs fixed in May 2026.
+
+Bug A — IRI-form existential parsed as a bogus class
+    `<P> some <C>` was caught by an over-greedy `startsWith("<") &&
+    endsWith(">")` fast path in QueryParser.parse(), which stripped the
+    outer brackets and built an OWLClass from the malformed middle. The
+    reasoner then returned only unsatisfiable classes (trivially subsumed
+    by anything), which looked like "0 results" for clean ontologies (GO)
+    and like nonsense for ontologies with unsatisfiable classes (pizza).
+
+Bug B — label-form existential rejected by Manchester parser
+    `'P' some 'C'` failed because BasicEntityChecker.getOWLObjectProperty()
+    only did direct IRI lookup. With no label/fragment fallback, the parser
+    could not resolve `'part of'` as a property, so the whole expression
+    failed to parse.
+
+Both bugs return parser errors / wrong results that masquerade as
+"slowness" in the UI (the user retries; the page is empty).
+
+Run against a worker that has pizza and/or go loaded:
+
+    BASE_URL=http://localhost:8081/api pytest tests/aberowlapi/test_dl_query_bugs.py -v
+
+Tests skip individually when the needed ontology isn't loaded, so this is
+safe to run against any worker.
+"""
+import os
+import pytest
+import requests
+
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8081/api")
+PIZZA = "http://www.co-ode.org/ontologies/pizza/pizza.owl#"
+OBO = "http://purl.obolibrary.org/obo/"
+
+
+def _loaded_ontologies():
+    """Return set of currently-classified ontologyIds on the target worker."""
+    try:
+        r = requests.get(f"{BASE_URL}/listLoadedOntologies.groovy", timeout=5)
+        r.raise_for_status()
+        return {
+            o["ontologyId"]
+            for o in r.json().get("ontologies", [])
+            if o.get("status") == "classified"
+        }
+    except Exception:
+        return set()
+
+
+LOADED = _loaded_ontologies()
+
+
+def _run_query(ontology_id, query, *, qtype="subclass", direct="false", labels="true"):
+    """POST a query to /runQuery.groovy, return (results_list, raw_json)."""
+    r = requests.get(
+        f"{BASE_URL}/runQuery.groovy",
+        params={
+            "ontologyId": ontology_id,
+            "query": query,
+            "type": qtype,
+            "direct": direct,
+            "labels": labels,
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    body = r.json()
+    return body.get("result", []), body
+
+
+def _class_iris(results):
+    """Extract the class IRI (without angle brackets) from each result entry."""
+    return {r.get("class") for r in results if r.get("class")}
+
+
+# -------------------------------------------------------------------- pizza
+
+requires_pizza = pytest.mark.skipif(
+    "pizza" not in LOADED, reason="pizza ontology not loaded on worker"
+)
+
+
+@requires_pizza
+def test_bug_a_iri_existential_returns_real_pizzas():
+    """Bug A regression: `<hasTopping> some <MozzarellaTopping>` returns real
+    pizzas, not just the two unsatisfiable classes (CheeseyVegetableTopping,
+    IceCream) that the buggy parser returned for any unknown class.
+    """
+    results, _ = _run_query(
+        "pizza",
+        f"<{PIZZA}hasTopping> some <{PIZZA}MozzarellaTopping>",
+    )
+    iris = _class_iris(results)
+    # Real pizzas with mozzarella — at minimum Margherita and American.
+    assert f"{PIZZA}Margherita" in iris, (
+        f"Margherita missing from existential subclass query — Bug A may have regressed. "
+        f"Got {len(iris)} results: {sorted(iris)[:10]}"
+    )
+    assert f"{PIZZA}American" in iris
+    # Should be substantially more than the 2 unsatisfiable classes the bug
+    # used to return for any unknown class.
+    assert len(iris) > 5, f"Only {len(iris)} results; bug-A symptom (≤2) may have returned"
+
+
+@requires_pizza
+def test_bug_b_label_existential_matches_iri_existential():
+    """Bug B regression: the label-form existential resolves the same class
+    set as the IRI-form. They are semantically equivalent queries.
+    """
+    iri_results, _ = _run_query(
+        "pizza",
+        f"<{PIZZA}hasTopping> some <{PIZZA}MozzarellaTopping>",
+    )
+    label_results, _ = _run_query(
+        "pizza",
+        "'has topping' some 'MozzarellaTopping'",
+    )
+    assert _class_iris(iri_results) == _class_iris(label_results), (
+        "IRI and label forms diverged. Bug B fallback in "
+        "BasicEntityChecker.getOWLObjectProperty may have regressed."
+    )
+
+
+@requires_pizza
+def test_sanity_single_iri_still_resolves():
+    """Single `<IRI>` queries must still resolve to the named class, not a
+    fresh OWLClass with a bogus IRI. We just check the call doesn't error
+    and returns a stable result set.
+    """
+    results, body = _run_query("pizza", f"<{PIZZA}MozzarellaTopping>")
+    assert "error" not in body
+    # MozzarellaTopping has at least the two unsatisfiable subclasses
+    # baked into pizza.owl on purpose.
+    assert isinstance(results, list)
+
+
+@requires_pizza
+def test_bogus_iri_does_not_return_unsatisfiable_noise():
+    """A clearly-fake `<http://example.org/foo>` IRI must not silently return
+    unsatisfiable classes as if they were subclasses of it. With the parser
+    fix the Manchester parser raises (400 / parser error). Either an error
+    response or empty result is acceptable — what's *not* acceptable is the
+    pre-fix behaviour of returning CheeseyVegetableTopping / IceCream.
+    """
+    try:
+        results, body = _run_query("pizza", "<http://example.org/foo>")
+    except requests.HTTPError:
+        return  # 400 is acceptable
+    iris = _class_iris(results)
+    # The unsatisfiable noise pattern the bug used to surface.
+    BUGGY_NOISE = {
+        f"{PIZZA}CheeseyVegetableTopping",
+        f"{PIZZA}IceCream",
+    }
+    assert not (iris & BUGGY_NOISE), (
+        f"Bogus IRI returned unsatisfiable classes as 'subclasses' — "
+        f"bug-A symptom regressed. Got: {iris}"
+    )
+
+
+# ----------------------------------------------------------------------- go
+
+requires_go = pytest.mark.skipif(
+    "go" not in LOADED, reason="go ontology not loaded on worker"
+)
+
+
+@requires_go
+def test_bug_a_go_part_of_apoptotic_process():
+    """The canonical bug-A repro query against GO. Old aberowl returns ~44;
+    pre-fix aberowl2 returned 0; post-fix should be >0 and the labels should
+    look apoptosis-related (semantic sanity check on the reasoner output).
+    """
+    results, _ = _run_query(
+        "go",
+        f"<{OBO}BFO_0000050> some <{OBO}GO_0006915>",
+    )
+    iris = _class_iris(results)
+    assert len(iris) > 10, (
+        f"Only {len(iris)} subclasses of `part_of some apoptotic process` — "
+        f"bug A may have regressed."
+    )
+    # The returned classes must be apoptosis-related — guards against the
+    # bug returning unrelated noise classes.
+    labels_joined = " ".join(
+        (r.get("label") or "").lower() for r in results
+    )
+    assert "apopto" in labels_joined, (
+        f"Result labels look unrelated to apoptosis; reasoner output may be wrong. "
+        f"Sample: {[r.get('label') for r in results[:5]]}"
+    )
+
+
+@requires_go
+def test_bug_b_go_label_existential_matches_iri():
+    """Label-form `'part of' some 'apoptotic process'` on GO must match the
+    IRI-form result set exactly.
+    """
+    iri_results, _ = _run_query(
+        "go",
+        f"<{OBO}BFO_0000050> some <{OBO}GO_0006915>",
+    )
+    label_results, _ = _run_query(
+        "go",
+        "'part of' some 'apoptotic process'",
+    )
+    assert _class_iris(iri_results) == _class_iris(label_results), (
+        "GO label-form existential diverged from IRI-form. "
+        "Bug B fallback in BasicEntityChecker.getOWLObjectProperty may have regressed."
+    )
+
+
+@requires_go
+def test_sanity_go_roots_unchanged():
+    """`owl:Thing` direct subclasses on GO must be the three canonical roots.
+    Guards against the parser fix breaking the basic hierarchy path.
+    """
+    results, _ = _run_query(
+        "go",
+        "<http://www.w3.org/2002/07/owl#Thing>",
+        direct="true",
+    )
+    iris = _class_iris(results)
+    assert iris == {
+        f"{OBO}GO_0008150",  # biological_process
+        f"{OBO}GO_0005575",  # cellular_component
+        f"{OBO}GO_0003674",  # molecular_function
+    }, f"GO roots unexpected: {iris}"
+
+
+@requires_go
+def test_sanity_go_bare_label_class():
+    """Bare labels like `apoptotic process` must still resolve to the GO
+    class and return its subclass hierarchy (this is the most common UI
+    interaction).
+    """
+    results, _ = _run_query("go", "apoptotic process")
+    assert len(results) > 50, (
+        f"Only {len(results)} subclasses for bare label 'apoptotic process'; "
+        f"label resolution may have regressed."
+    )


### PR DESCRIPTION
Work from migrating the AberOWL2 fleet to the corrected distribution and right-sizing every worker. Production (onto) is already running the two code changes below; this PR gets them into version control / main.

## Key changes (deployed + verified on onto)
- **fix(worker): suppress owl:imports** (`RequestManager.groovy`) — SILENT + an IRI mapper that maps every import to a unique non-existent path, so OWLAPI never hits the network. Dead/remote imports were hanging loads for minutes and OOMing workers. The whole migrated fleet runs on this.
- **perf(central): write the registry backup file once per refresh cycle, not once per server** (`main.py`) — the 60s metadata refresh was calling `_write_servers_to_file()` ~860×/cycle (each a synchronous full-list `json.dump` to disk, O(n²)), blocking the asyncio event loop and causing intermittent 10–50s query stalls. Now ~0.1s even during a refresh.

## Tooling (`scripts/`, `deploy/`)
- `repoint_ontology.py` — direct-Redis registry repoint with retry (central's refresh can clobber a write).
- `rebuild_lbucket.py` — rebuild workers in place from the registry keep-set; measure live heap → right-size.
- `plan_distribution.py` — pin ABox-heavy "giant" ontologies to a dedicated worker; fail-loud on-disk guard.
- `normalize_manchester_annotations.py`, `convert_owl_legacy.groovy` — fixups for malformed/legacy OWL files.
- `retry_downloads.py`, benchmarks, `worker_measurements` ledger.

## Notes
- Includes some older un-merged commits already on this branch (SPARQL-UI page, dispatcher runQuery, root-class precompute).
- A WIP central batch-dispatch change is intentionally **not** included (left uncommitted).