### PR TITLE
Web UI: linkable URLs, full metadata, DL-query UX, accessibility; fix dl_expressivity

### DIFF
--- a/aberowlapi/api/getStatistics.groovy
+++ b/aberowlapi/api/getStatistics.groovy
@@ -197,8 +197,13 @@ def rboxAxiomsCount = ontology.getRBoxAxioms(Imports.INCLUDED).size()
 
 def declarationAxiomsCount = ontology.getAxioms(AxiomType.DECLARATION, true).size()
 
-def checker = new DLExpressivity(ontology)
-def dlExpressivity = checker.getValue()
+// Report a canonical DL name (e.g. "ALC", "ALCHIQ") instead of a raw
+// concatenation of construct letters, which produced garbled strings like
+// "CCINTERI". expressibleInLanguages() maps the constructs onto the standard
+// DL family names; fall back to the construct list when no named language fits.
+def checker = new DLExpressivityChecker(Collections.singleton(ontology))
+def expressibleLangs = checker.expressibleInLanguages()
+def dlExpressivity = expressibleLangs ? expressibleLangs.collect { it.toString() }.join(", ") : checker.getDescriptionLogicName()
 
 def exampleSuperclassLabel = manager.exampleSuperclassLabels.get(ontologyId) ?: ""
 def exampleSubclassExpression = manager.exampleSubclassExpressions.get(ontologyId) ?: ""

--- a/central_server/app/intake/bioportal.py
+++ b/central_server/app/intake/bioportal.py
@@ -7,6 +7,7 @@ download URLs. Ontologies already registered from OBOFoundry are skipped.
 
 import asyncio
 import logging
+import os
 from typing import Any, Dict, List, Optional, Set
 
 import aiohttp
@@ -14,7 +15,10 @@ import aiohttp
 logger = logging.getLogger(__name__)
 
 BIOPORTAL_API_URL = "https://data.bioontology.org"
-BIOPORTAL_API_KEY = "7LWB1EK24e8Pj7XorQdG9FnsxQA3H41VDKIxN1BeEv5n"
+# Configurable via env (BioPortal keys expire); falls back to the bundled key.
+BIOPORTAL_API_KEY = os.getenv(
+    "BIOPORTAL_API_KEY", "7LWB1EK24e8Pj7XorQdG9FnsxQA3H41VDKIxN1BeEv5n"
+)
 
 # Max concurrent requests to BioPortal to avoid rate limiting
 _CONCURRENCY_LIMIT = 5
@@ -87,6 +91,35 @@ async def _fetch_download_url(
         if isinstance(download, str) and download.startswith("http"):
             return download
         return None
+
+
+async def fetch_bioportal_metadata() -> List[Dict[str, Any]]:
+    """Fetch lightweight metadata (name, description, homepage) for every
+    BioPortal ontology, WITHOUT resolving per-ontology download URLs.
+
+    Used to backfill registry metadata (title/description/homepage) for
+    ontologies that are not in OBO Foundry. Returns an empty list if BioPortal
+    is unreachable or the API key is invalid.
+    """
+    async with aiohttp.ClientSession() as session:
+        raw_list = await _fetch_all_ontologies(session)
+
+    records: List[Dict[str, Any]] = []
+    for o in raw_list:
+        acronym = o.get("acronym", "")
+        if not acronym:
+            continue
+        records.append(
+            {
+                "ontology_id": acronym.lower(),
+                "name": o.get("name", acronym),
+                "description": o.get("description", ""),
+                "homepage": f"https://bioportal.bioontology.org/ontologies/{acronym}",
+                "license": "",
+            }
+        )
+    logger.info("BioPortal: fetched metadata for %d ontologies", len(records))
+    return records
 
 
 async def fetch_bioportal_ontologies(exclude_ids: Set[str]) -> List[Dict[str, Any]]:

--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -29,7 +29,7 @@ from app.auth import (
     PUBLIC_RATE_LIMIT, API_KEY_RATE_LIMIT,
 )
 from app.intake.obofoundry import fetch_obofoundry_ontologies
-from app.intake.bioportal import fetch_bioportal_ontologies
+from app.intake.bioportal import fetch_bioportal_ontologies, fetch_bioportal_metadata
 from app.intake import updater as update_pipeline
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -321,11 +321,9 @@ async def fetch_and_update_server_metadata(server: Dict[str, Any]):
                     stats = await response.json()
                     server.update(stats)
                     server["status"] = "online"
-                    # If the worker didn't provide a title, use OBO Foundry fallback
-                    if not server.get("title"):
-                        fallback = _obo_titles.get(ontology.lower(), "")
-                        if fallback:
-                            server["title"] = fallback
+                    # Backfill any fields the OWL file didn't carry (title,
+                    # description, homepage, license, contact) from OBO Foundry.
+                    _apply_registry_fallbacks(server)
                     logger.info(f"Successfully updated metadata for {ontology} (title: {server.get('title', '')})")
                 else:
                     logger.warning(f"Failed to fetch metadata for {ontology}. Status: {response.status}")
@@ -334,11 +332,9 @@ async def fetch_and_update_server_metadata(server: Dict[str, Any]):
         logger.error(f"Error fetching metadata for {ontology}: {e}")
         server["status"] = "offline"
 
-    # Always apply OBO Foundry title fallback if title is missing
-    if not server.get("title"):
-        fallback = _obo_titles.get(ontology.lower(), "")
-        if fallback:
-            server["title"] = fallback
+    # Always apply registry fallbacks for any still-empty fields (e.g. when the
+    # worker was unreachable above, title can still come from the cache).
+    _apply_registry_fallbacks(server)
 
     # Update the server data in Redis
     await redis_client.hset("registered_servers", ontology, json.dumps(server))
@@ -379,6 +375,10 @@ async def start_mcp_servers():
 
 # Cache of ontology titles from OBO Foundry + BioPortal known names
 _obo_titles: Dict[str, str] = {}
+# Cache of richer OBO Foundry registry metadata, keyed by lowercase ontology id.
+# Used to backfill fields the OWL file itself does not carry (homepage, license,
+# description, contact).
+_obo_metadata: Dict[str, Dict[str, Any]] = {}
 
 OBO_REGISTRY_URL = "https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.jsonld"
 
@@ -396,10 +396,23 @@ _KNOWN_TITLES: Dict[str, str] = {
 }
 
 
+def _normalize_contact(contact: Any) -> Any:
+    """Reduce an OBO Foundry contact object to a display-friendly value."""
+    if isinstance(contact, dict):
+        label = contact.get("label") or contact.get("github")
+        email = contact.get("email")
+        if label and email:
+            return f"{label} <{email}>"
+        return label or email or ""
+    return contact or ""
+
+
 async def _load_obo_foundry_titles():
-    """Fetch ontology titles from OBO Foundry registry as fallback for ontologies
-    that don't have dc:title/rdfs:label in their OWL file."""
-    global _obo_titles
+    """Fetch ontology metadata from the OBO Foundry registry as a fallback for
+    ontologies that don't carry it in their OWL file. Populates both the title
+    cache and the richer `_obo_metadata` cache (description, homepage, license,
+    contact)."""
+    global _obo_titles, _obo_metadata
     _obo_titles.update(_KNOWN_TITLES)
     try:
         async with aiohttp.ClientSession() as session:
@@ -408,12 +421,101 @@ async def _load_obo_foundry_titles():
                     data = await resp.json(content_type=None)
                     for o in data.get("ontologies", []):
                         oid = o.get("id", "")
+                        if not oid:
+                            continue
+                        key = oid.lower()
                         title = o.get("title", "")
-                        if oid and title:
-                            _obo_titles[oid.lower()] = title
-                    logger.info(f"Loaded {len(_obo_titles)} ontology titles from OBO Foundry registry")
+                        if title:
+                            _obo_titles[key] = title
+                        license_info = o.get("license", {})
+                        license_url = ""
+                        if isinstance(license_info, dict):
+                            license_url = license_info.get("url", "") or license_info.get("label", "")
+                        elif isinstance(license_info, str):
+                            license_url = license_info
+                        _obo_metadata[key] = {
+                            "title": title,
+                            "description": o.get("description", ""),
+                            "home_page": o.get("homepage", ""),
+                            "license": license_url,
+                            "contact": _normalize_contact(o.get("contact")),
+                        }
+                    logger.info(
+                        f"Loaded {len(_obo_titles)} titles / {len(_obo_metadata)} metadata "
+                        f"records from OBO Foundry registry"
+                    )
     except Exception as e:
         logger.warning(f"Could not fetch OBO Foundry titles: {e}")
+
+
+async def _load_bioportal_metadata():
+    """Backfill the metadata cache with BioPortal titles/descriptions for ids
+    that OBO Foundry does not already cover (OBO Foundry takes precedence).
+    Then re-apply fallbacks to already-registered servers so the new metadata
+    is reflected without waiting for the next worker poll. No-op if BioPortal is
+    unreachable or its API key is invalid."""
+    global _obo_titles, _obo_metadata
+    try:
+        records = await fetch_bioportal_metadata()
+    except Exception as e:
+        logger.warning(f"Could not fetch BioPortal metadata: {e}")
+        return
+
+    added = 0
+    for rec in records:
+        key = rec.get("ontology_id", "")
+        if not key or key in _obo_metadata:
+            continue  # OBO Foundry entry wins
+        title = rec.get("name", "")
+        if title:
+            _obo_titles.setdefault(key, title)
+        _obo_metadata[key] = {
+            "title": title,
+            "description": rec.get("description", ""),
+            "home_page": rec.get("homepage", ""),
+            "license": rec.get("license", ""),
+            "contact": "",
+        }
+        added += 1
+
+    logger.info(
+        f"Loaded {added} BioPortal metadata records (cache now {len(_obo_metadata)})"
+    )
+    if added:
+        await _reapply_registry_fallbacks_to_all()
+
+
+async def _reapply_registry_fallbacks_to_all():
+    """Re-apply metadata fallbacks to every registered server, persisting any
+    entry whose fields changed. Cheap: touches only Redis, no worker polling."""
+    server_keys = await redis_client.hkeys("registered_servers")
+    updated = 0
+    for key in server_keys or []:
+        raw = await redis_client.hget("registered_servers", key)
+        if not raw:
+            continue
+        server = json.loads(raw)
+        snapshot = {f: server.get(f) for f in ("title", "description", "home_page", "license", "contact")}
+        _apply_registry_fallbacks(server)
+        if any(server.get(f) != snapshot[f] for f in snapshot):
+            await redis_client.hset("registered_servers", key, json.dumps(server))
+            updated += 1
+    if updated:
+        await _write_servers_to_file()
+        logger.info(f"Re-applied registry fallbacks; updated {updated} server entries")
+
+
+def _apply_registry_fallbacks(server: Dict[str, Any]):
+    """Backfill empty metadata fields on a registry entry from the OBO Foundry /
+    BioPortal registry cache. OWL-file-derived values always win; this only
+    fills blanks."""
+    ontology = (server.get("ontology") or "").lower()
+    meta = _obo_metadata.get(ontology)
+    if not meta:
+        return
+    for field in ("title", "description", "home_page", "license", "contact"):
+        if not server.get(field) and meta.get(field):
+            server[field] = meta[field]
 
 
 async def _fetch_and_update_all_servers():
@@ -464,8 +566,10 @@ async def lifespan(app: FastAPI):
     # Load servers from file before fetching metadata
     await _load_servers_from_file()
 
-    # Load OBO Foundry titles for fallback
+    # Load OBO Foundry titles/metadata for fallback (fast, blocking).
     await _load_obo_foundry_titles()
+    # Backfill remaining ids from BioPortal in the background (slower, optional).
+    asyncio.create_task(_load_bioportal_metadata())
 
     # Perform initial metadata fetch on startup
     asyncio.create_task(_fetch_and_update_all_servers())

--- a/central_server/frontend/src/api/client.ts
+++ b/central_server/frontend/src/api/client.ts
@@ -29,9 +29,10 @@ export async function getOntology(id: string): Promise<OntologyDetail> {
   return get<OntologyDetail>('/api/getOntology', { ontology: id })
 }
 
-export async function searchClasses(query: string, ontology?: string, size = 100): Promise<ClassResult[]> {
+export async function searchClasses(query: string, ontology?: string, size = 100, prefix = false): Promise<ClassResult[]> {
   const params: Record<string, string> = { query, size: String(size) }
   if (ontology) params.ontologies = ontology
+  if (prefix) params.prefix = 'true'
   const data = await get<{ result: ClassResult[] }>('/api/search_all', params)
   return data.result
 }

--- a/central_server/frontend/src/api/types.ts
+++ b/central_server/frontend/src/api/types.ts
@@ -14,10 +14,26 @@ export interface OntologyDetail {
   property_count: number
   object_property_count: number
   data_property_count: number
+  annotation_property_count?: number
   individual_count: number
   version_info: string
+  version_iri?: string
   license: string
   home_page: string
+  documentation?: string
+  publication?: string
+  creators?: string[]
+  contact?: string | string[] | Record<string, unknown> | null
+  default_namespace?: string
+  obo_format_version?: string
+  reasoner_type?: string
+  dl_expressivity?: string
+  axiom_count?: number
+  logical_axiom_count?: number
+  tbox_axiom_count?: number
+  abox_axiom_count?: number
+  rbox_axiom_count?: number
+  declaration_axiom_count?: number
 }
 
 export interface ClassResult {

--- a/central_server/frontend/src/codemirror/sparqlMode.ts
+++ b/central_server/frontend/src/codemirror/sparqlMode.ts
@@ -1,0 +1,67 @@
+import { StreamLanguage } from '@codemirror/language'
+
+const KEYWORDS = new Set([
+  'select', 'construct', 'describe', 'ask', 'where', 'from', 'named', 'prefix', 'base',
+  'optional', 'union', 'minus', 'filter', 'bind', 'values', 'service', 'graph',
+  'order', 'by', 'group', 'having', 'limit', 'offset', 'distinct', 'reduced',
+  'as', 'a', 'asc', 'desc', 'not', 'exists', 'in', 'true', 'false',
+  // AberOWL DL-frame keywords
+  'owl', 'subeq', 'subclass', 'superclass', 'supeq', 'equivalent',
+])
+
+const FUNCTIONS = new Set([
+  'str', 'lang', 'langmatches', 'datatype', 'bound', 'iri', 'uri', 'bnode',
+  'rand', 'abs', 'ceil', 'floor', 'round', 'concat', 'strlen', 'ucase', 'lcase',
+  'contains', 'strstarts', 'strends', 'strbefore', 'strafter', 'regex', 'replace',
+  'count', 'sum', 'min', 'max', 'avg', 'sample', 'group_concat', 'coalesce', 'if',
+])
+
+/** Minimal SPARQL (+ AberOWL OWL-frame) syntax mode for CodeMirror. */
+export const sparql = StreamLanguage.define({
+  name: 'sparql',
+  token(stream) {
+    if (stream.eatSpace()) return null
+
+    // Comments
+    if (stream.match('#')) { stream.skipToEnd(); return 'comment' }
+
+    // IRIs <...>
+    if (stream.match(/^<[^>\s]*>/)) return 'string.special'
+
+    // Strings (single, double, triple)
+    const ch = stream.peek()
+    if (ch === '"' || ch === "'") {
+      const q = stream.next()!
+      let prev = ''
+      while (!stream.eol()) {
+        const c = stream.next()!
+        if (c === q && prev !== '\\') break
+        prev = c
+      }
+      return 'string'
+    }
+
+    // Variables ?x $x
+    if (stream.match(/^[?$][A-Za-z_][\w]*/)) return 'variableName'
+
+    // Numbers
+    if (stream.match(/^-?\d+\.?\d*([eE][+-]?\d+)?/)) return 'number'
+
+    // Prefixed names foo:bar  (and bare a)
+    if (stream.match(/^[A-Za-z_][\w.-]*:[\w.-]*/)) return 'typeName'
+
+    // Words / keywords
+    if (stream.match(/^[A-Za-z_][\w]*/)) {
+      const word = (stream.current() || '').toLowerCase()
+      if (KEYWORDS.has(word)) return 'keyword'
+      if (FUNCTIONS.has(word)) return 'function'
+      return null
+    }
+
+    // Operators / punctuation
+    if (stream.match(/^[{}().;,*=<>!+\-/|^]/)) return 'operator'
+
+    stream.next()
+    return null
+  },
+})

--- a/central_server/frontend/src/components/Combobox.tsx
+++ b/central_server/frontend/src/components/Combobox.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+export interface ComboboxOption {
+  value: string
+  label: string
+  /** Optional secondary text shown muted after the label */
+  hint?: string
+}
+
+interface Props {
+  options: ComboboxOption[]
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  /** Label for the value === '' choice (e.g. "All ontologies"); omit to hide it */
+  allLabel?: string
+  className?: string
+  id?: string
+}
+
+/**
+ * Searchable, keyboard-navigable single-select combobox. Replaces a native
+ * <select> when the option count is large (hundreds of ontologies).
+ */
+export default function Combobox({
+  options, value, onChange, placeholder = 'Search…', allLabel, className = '', id,
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [active, setActive] = useState(0)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  const all: ComboboxOption[] = useMemo(
+    () => (allLabel ? [{ value: '', label: allLabel }, ...options] : options),
+    [options, allLabel],
+  )
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return all
+    return all.filter(o =>
+      o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q) ||
+      (o.hint || '').toLowerCase().includes(q))
+  }, [all, query])
+
+  const selected = all.find(o => o.value === value)
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    function onDoc(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  // Keep active item in view
+  useEffect(() => {
+    if (!open || !listRef.current) return
+    const el = listRef.current.children[active] as HTMLElement | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [active, open])
+
+  function commit(opt: ComboboxOption) {
+    onChange(opt.value)
+    setOpen(false)
+    setQuery('')
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (!open && (e.key === 'ArrowDown' || e.key === 'Enter')) { setOpen(true); return }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive(a => Math.min(a + 1, filtered.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); if (filtered[active]) commit(filtered[active]) }
+    else if (e.key === 'Escape') { setOpen(false); setQuery('') }
+  }
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <input
+        id={id}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={id ? `${id}-listbox` : undefined}
+        aria-autocomplete="list"
+        value={open ? query : (selected?.label ?? '')}
+        placeholder={selected ? selected.label : placeholder}
+        onChange={e => { setQuery(e.target.value); setActive(0); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 focus:outline-none"
+      />
+      {open && (
+        <ul
+          ref={listRef}
+          id={id ? `${id}-listbox` : undefined}
+          role="listbox"
+          className="absolute z-50 mt-1 w-full max-h-72 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg text-sm"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-3 py-2 text-gray-400">No matches</li>
+          ) : (
+            filtered.map((o, i) => (
+              <li
+                key={o.value || '__all__'}
+                role="option"
+                aria-selected={o.value === value}
+                onMouseDown={e => { e.preventDefault(); commit(o) }}
+                onMouseEnter={() => setActive(i)}
+                className={`px-3 py-1.5 cursor-pointer flex items-center gap-2 ${
+                  i === active ? 'bg-indigo-50' : ''
+                } ${o.value === value ? 'font-semibold text-indigo-700' : 'text-gray-700'}`}
+              >
+                <span className="truncate">{o.label}</span>
+                {o.hint && <span className="text-xs text-gray-400 truncate">{o.hint}</span>}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/central_server/frontend/src/components/Layout.tsx
+++ b/central_server/frontend/src/components/Layout.tsx
@@ -1,15 +1,10 @@
-import { Link, Outlet, useNavigate, useLocation } from 'react-router-dom'
+import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useState } from 'react'
+import SearchBox from './SearchBox'
 
 export default function Layout() {
-  const [q, setQ] = useState('')
-  const nav = useNavigate()
   const loc = useLocation()
-
-  function onSearch(e: React.FormEvent) {
-    e.preventDefault()
-    if (q.trim()) { nav(`/search?q=${encodeURIComponent(q.trim())}`); setQ('') }
-  }
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const navItems = [
     { to: '/', label: 'Ontologies' },
@@ -20,7 +15,7 @@ export default function Layout() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <header className="bg-white border-b border-gray-200 sticky top-0 z-40 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 h-14 flex items-center gap-6">
+        <div className="max-w-7xl mx-auto px-4 h-14 flex items-center gap-4">
           <Link to="/" className="text-xl font-extrabold text-indigo-700 shrink-0 tracking-tight">
             AberOWL
           </Link>
@@ -36,15 +31,42 @@ export default function Layout() {
               </Link>
             ))}
           </nav>
-          <form onSubmit={onSearch} className="flex-1 max-w-md ml-auto">
-            <input
-              value={q}
-              onChange={e => setQ(e.target.value)}
-              placeholder="Search classes..."
-              className="w-full px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
-            />
-          </form>
+          <SearchBox
+            className="flex-1 max-w-md ml-auto"
+            clearOnNavigate
+            placeholder="Search classes…"
+            inputClassName="w-full px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
+          />
+          {/* Mobile menu button */}
+          <button
+            className="md:hidden p-2 -mr-1 text-gray-600 hover:text-gray-900 shrink-0"
+            aria-label="Toggle navigation menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen(o => !o)}
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              {menuOpen
+                ? <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                : <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />}
+            </svg>
+          </button>
         </div>
+        {/* Mobile nav drawer */}
+        {menuOpen && (
+          <nav className="md:hidden border-t border-gray-100 bg-white px-4 py-2 flex flex-col gap-1 text-sm">
+            {navItems.map(n => (
+              <Link key={n.to} to={n.to}
+                onClick={() => setMenuOpen(false)}
+                className={`px-3 py-2 rounded-md transition-colors ${
+                  loc.pathname === n.to
+                    ? 'bg-indigo-50 text-indigo-700 font-medium'
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                }`}>
+                {n.label}
+              </Link>
+            ))}
+          </nav>
+        )}
       </header>
       <main className="flex-1">
         <Outlet />

--- a/central_server/frontend/src/components/OWLExpression.tsx
+++ b/central_server/frontend/src/components/OWLExpression.tsx
@@ -95,9 +95,9 @@ function tokenize(expr: string): Token[] {
     }
 
     // Word or number
-    if (/[a-zA-Z0-9_:.\-]/.test(expr[i])) {
+    if (/[a-zA-Z0-9_:.-]/.test(expr[i])) {
       let word = ''
-      while (i < expr.length && /[a-zA-Z0-9_:.\-#\/]/.test(expr[i])) { word += expr[i]; i++ }
+      while (i < expr.length && /[a-zA-Z0-9_:.#/-]/.test(expr[i])) { word += expr[i]; i++ }
       if (OWL_KEYWORDS.has(word)) {
         tokens.push({ type: 'keyword', text: word })
       } else if (OWL_BUILTINS.has(word)) {

--- a/central_server/frontend/src/components/SearchBox.tsx
+++ b/central_server/frontend/src/components/SearchBox.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { searchClasses } from '../api/client'
+import type { ClassResult } from '../api/types'
+
+interface Props {
+  /** Tailwind sizing/extra classes for the wrapper */
+  className?: string
+  inputClassName?: string
+  placeholder?: string
+  /** Clear the input after navigating (used in the header) */
+  clearOnNavigate?: boolean
+  autoFocus?: boolean
+}
+
+function label(c: ClassResult): string {
+  return (Array.isArray(c.label) ? c.label[0] : c.label) || c.class
+}
+
+/** Search input with debounced class-name autocomplete across all ontologies. */
+export default function SearchBox({
+  className = '', inputClassName = '', placeholder = 'Search classes…', clearOnNavigate, autoFocus,
+}: Props) {
+  const [q, setQ] = useState('')
+  const [suggestions, setSuggestions] = useState<ClassResult[]>([])
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(-1)
+  const nav = useNavigate()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const seq = useRef(0)
+
+  useEffect(() => {
+    const term = q.trim()
+    const mySeq = ++seq.current
+    const t = setTimeout(() => {
+      if (term.length < 2) { if (seq.current === mySeq) setSuggestions([]); return }
+      searchClasses(term, undefined, 8, true)
+        .then(r => { if (seq.current === mySeq) { setSuggestions(r); setOpen(true) } })
+        .catch(() => { if (seq.current === mySeq) setSuggestions([]) })
+    }, 200)
+    return () => clearTimeout(t)
+  }, [q])
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [])
+
+  function goToSearch() {
+    const term = q.trim()
+    if (!term) return
+    nav(`/search?q=${encodeURIComponent(term)}`)
+    setOpen(false)
+    if (clearOnNavigate) setQ('')
+  }
+
+  function goToClass(c: ClassResult) {
+    nav(`/ontology/${c.ontology}/class/${encodeURIComponent(c.class)}`)
+    setOpen(false)
+    if (clearOnNavigate) setQ('')
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setOpen(true); setActive(a => Math.min(a + 1, suggestions.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(a => Math.max(a - 1, -1)) }
+    else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (open && active >= 0 && suggestions[active]) goToClass(suggestions[active])
+      else goToSearch()
+    } else if (e.key === 'Escape') { setOpen(false); setActive(-1) }
+  }
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <form onSubmit={e => { e.preventDefault(); goToSearch() }}>
+        <input
+          value={q}
+          autoFocus={autoFocus}
+          onChange={e => { setQ(e.target.value); setActive(-1) }}
+          onFocus={() => suggestions.length && setOpen(true)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          role="combobox"
+          aria-expanded={open}
+          aria-autocomplete="list"
+          className={inputClassName}
+        />
+      </form>
+      {open && suggestions.length > 0 && (
+        <ul
+          role="listbox"
+          className="absolute z-50 mt-1 w-full max-h-80 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg text-sm text-left"
+        >
+          {suggestions.map((c, i) => (
+            <li
+              key={c.class || i}
+              role="option"
+              aria-selected={i === active}
+              onMouseEnter={() => setActive(i)}
+              onMouseDown={e => { e.preventDefault(); goToClass(c) }}
+              className={`px-3 py-2 cursor-pointer flex items-center gap-2 ${i === active ? 'bg-indigo-50' : ''}`}
+            >
+              <span className="flex-1 min-w-0 truncate text-gray-800">{label(c)}</span>
+              <span className="text-[10px] uppercase bg-indigo-100 text-indigo-700 px-1.5 py-0.5 rounded shrink-0">
+                {c.ontology}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/central_server/frontend/src/components/StateMessage.tsx
+++ b/central_server/frontend/src/components/StateMessage.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  kind?: 'error' | 'empty'
+  title: string
+  detail?: string
+  onRetry?: () => void
+}
+
+/** Inline error / empty placeholder with an optional retry action. */
+export default function StateMessage({ kind = 'empty', title, detail, onRetry }: Props) {
+  const isError = kind === 'error'
+  return (
+    <div className={`rounded-lg border p-6 text-center text-sm ${
+      isError ? 'border-red-200 bg-red-50 text-red-700' : 'border-gray-200 bg-white text-gray-500'
+    }`}>
+      <p className="font-medium">{title}</p>
+      {detail && <p className="mt-1 text-xs opacity-80 break-words">{detail}</p>}
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-3 px-3 py-1.5 rounded-md border border-current text-xs font-medium hover:opacity-80"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/central_server/frontend/src/components/TreeNode.tsx
+++ b/central_server/frontend/src/components/TreeNode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ClassResult } from '../api/types'
 import { dlQuery } from '../api/client'
@@ -11,6 +11,8 @@ interface Props {
   onSelect?: (iri: string) => void
   /** Currently selected IRI (for highlighting) */
   selectedIri?: string | null
+  /** Ancestor IRIs to auto-expand (deep-link restore) */
+  expandPath?: Set<string>
 }
 
 function isObsolete(node: ClassResult): boolean {
@@ -31,7 +33,17 @@ function sortChildren(children: ClassResult[]): ClassResult[] {
   })
 }
 
-export default function TreeNode({ node, ontologyId, depth = 0, onSelect, selectedIri }: Props) {
+/** Move keyboard focus to the previous/next visible treeitem in the whole tree. */
+function moveFocus(current: HTMLElement, dir: 1 | -1) {
+  const tree = current.closest('[role="tree"]')
+  if (!tree) return
+  const items = Array.from(tree.querySelectorAll<HTMLElement>('[role="treeitem"] > [data-tree-focusable]'))
+  const idx = items.indexOf(current)
+  const next = items[idx + dir]
+  next?.focus()
+}
+
+export default function TreeNode({ node, ontologyId, depth = 0, onSelect, selectedIri, expandPath }: Props) {
   const [children, setChildren] = useState<ClassResult[] | null>(null)
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -41,19 +53,35 @@ export default function TreeNode({ node, ontologyId, depth = 0, onSelect, select
   const isSelected = selectedIri === iri
   const obsolete = isObsolete(node)
 
-  async function toggle() {
-    if (open) { setOpen(false); return }
-    if (children === null) {
-      setLoading(true)
-      try {
-        const q = iri.startsWith('http') ? `<${iri}>` : iri
-        const data = await dlQuery(q, 'subclass', ontologyId, true)
-        setChildren(sortChildren(data.result || []))
-      } catch { setChildren([]) }
+  async function loadChildren(): Promise<ClassResult[]> {
+    if (children !== null) return children
+    setLoading(true)
+    try {
+      const q = iri.startsWith('http') ? `<${iri}>` : iri
+      const data = await dlQuery(q, 'subclass', ontologyId, true)
+      const sorted = sortChildren(data.result || [])
+      setChildren(sorted)
+      return sorted
+    } catch {
+      setChildren([])
+      return []
+    } finally {
       setLoading(false)
     }
+  }
+
+  async function toggle() {
+    if (open) { setOpen(false); return }
+    await loadChildren()
     setOpen(true)
   }
+
+  // Auto-expand along a deep-link path
+  useEffect(() => {
+    if (open || !expandPath || !expandPath.has(iri)) return
+    loadChildren().then(() => setOpen(true))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandPath])
 
   const isLeaf = children !== null && children.length === 0
 
@@ -64,39 +92,65 @@ export default function TreeNode({ node, ontologyId, depth = 0, onSelect, select
     }
   }
 
+  function onKeyDown(e: React.KeyboardEvent<HTMLElement>) {
+    const el = e.currentTarget
+    switch (e.key) {
+      case 'ArrowDown': e.preventDefault(); moveFocus(el, 1); break
+      case 'ArrowUp': e.preventDefault(); moveFocus(el, -1); break
+      case 'ArrowRight': e.preventDefault(); if (!open && !isLeaf) toggle(); break
+      case 'ArrowLeft': e.preventDefault(); if (open) setOpen(false); break
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        if (onSelect) onSelect(iri)
+        break
+    }
+  }
+
   const labelClasses = obsolete
-    ? `text-sm text-left truncate leading-tight line-through text-gray-400 italic ${
-        isSelected ? 'font-semibold bg-red-100 px-1 -mx-1 rounded' : 'hover:text-gray-500'
+    ? `text-sm text-left truncate leading-tight line-through text-gray-400 italic outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded ${
+        isSelected ? 'font-semibold bg-red-100 px-1 -mx-1' : 'hover:text-gray-500'
       }`
-    : `text-sm text-left truncate leading-tight transition-colors ${
+    : `text-sm text-left truncate leading-tight transition-colors outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded ${
         isSelected
-          ? 'text-indigo-700 font-semibold bg-indigo-100 px-1 -mx-1 rounded'
+          ? 'text-indigo-700 font-semibold bg-indigo-100 px-1 -mx-1'
           : 'text-gray-700 hover:text-indigo-700'
       }`
 
-  const labelEl = onSelect ? (
-    <button onClick={handleClick} className={labelClasses} title={iri}>
+  const inner = (
+    <>
       {obsolete && <span className="text-[9px] text-red-400 font-normal not-italic mr-1">obsolete</span>}
       {lbl || iri}
+    </>
+  )
+
+  const labelEl = onSelect ? (
+    <button data-tree-focusable onClick={handleClick} onKeyDown={onKeyDown}
+      className={labelClasses} title={iri} tabIndex={0}>
+      {inner}
     </button>
   ) : (
-    <Link
-      to={`/ontology/${ontologyId}/class/${encodeURIComponent(iri)}`}
-      className={labelClasses}
-      title={iri}
-    >
-      {obsolete && <span className="text-[9px] text-red-400 font-normal not-italic mr-1">obsolete</span>}
-      {lbl || iri}
+    <Link data-tree-focusable to={`/ontology/${ontologyId}/class/${encodeURIComponent(iri)}`}
+      onKeyDown={onKeyDown} className={labelClasses} title={iri} tabIndex={0}>
+      {inner}
     </Link>
   )
 
   return (
-    <div className={depth > 0 ? 'ml-4 border-l border-gray-200' : ''}>
+    <div
+      role="treeitem"
+      aria-expanded={isLeaf ? undefined : open}
+      aria-selected={isSelected}
+      aria-level={depth + 1}
+      className={depth > 0 ? 'ml-4 border-l border-gray-200' : ''}
+    >
       <div className={`flex items-center gap-1 py-[3px] pl-2 group rounded-r transition-colors ${
         isSelected ? (obsolete ? 'bg-red-50' : 'bg-indigo-50') : 'hover:bg-gray-50'
       }`}>
         <button
           onClick={toggle}
+          aria-label={open ? 'Collapse' : 'Expand'}
+          tabIndex={-1}
           className={`w-5 h-5 flex items-center justify-center rounded text-xs shrink-0 transition-colors ${
             isLeaf ? 'text-gray-300' : obsolete ? 'text-gray-300 hover:text-gray-500' : 'text-gray-400 hover:text-indigo-600 hover:bg-indigo-100'
           }`}
@@ -114,7 +168,7 @@ export default function TreeNode({ node, ontologyId, depth = 0, onSelect, select
         {labelEl}
       </div>
       {open && children && children.length > 0 && (
-        <div>
+        <div role="group">
           {children.map((c, i) => (
             <TreeNode
               key={c.class || i}
@@ -123,6 +177,7 @@ export default function TreeNode({ node, ontologyId, depth = 0, onSelect, select
               depth={depth + 1}
               onSelect={onSelect}
               selectedIri={selectedIri}
+              expandPath={expandPath}
             />
           ))}
         </div>

--- a/central_server/frontend/src/hooks/useDocumentTitle.ts
+++ b/central_server/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+
+const SUFFIX = 'AberOWL'
+
+/** Set document.title to `parts... — AberOWL`, restoring nothing (SPA-wide). */
+export function useDocumentTitle(...parts: Array<string | null | undefined>) {
+  const title = [...parts.filter(Boolean), SUFFIX].join(' — ')
+  useEffect(() => {
+    document.title = title
+  }, [title])
+}

--- a/central_server/frontend/src/pages/ClassPage.tsx
+++ b/central_server/frontend/src/pages/ClassPage.tsx
@@ -3,16 +3,39 @@ import { useParams, Link } from 'react-router-dom'
 import { getClass, dlQuery } from '../api/client'
 import type { ClassResult } from '../api/types'
 import OWLExpression from '../components/OWLExpression'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 function asList(v: unknown): string[] {
   if (!v) return []
-  if (Array.isArray(v)) return v
+  if (Array.isArray(v)) return v.map(String)
   return [String(v)]
+}
+
+function labelOf(c: ClassResult): string {
+  return (Array.isArray(c.label) ? c.label[0] : c.label) || c.class
 }
 
 /** Strip HTML tags (the Groovy backend sometimes wraps axioms in <a> tags) */
 function stripHtml(s: string): string {
   return s.replace(/<[^>]*>/g, '')
+}
+
+/** Walk direct superclasses to build an ordered root→parent ancestor path. */
+async function ancestorChain(iri: string, ontologyId: string): Promise<ClassResult[]> {
+  const chain: ClassResult[] = []
+  const seen = new Set<string>([iri])
+  let current = iri
+  for (let i = 0; i < 50; i++) {
+    const q = current.startsWith('http') ? `<${current}>` : current
+    const supers = await dlQuery(q, 'superclass', ontologyId, true)
+      .then(d => d.result || []).catch(() => [])
+    const next = supers.find(s => s.class && !seen.has(s.class) && !/owl#Thing$/.test(s.class))
+    if (!next?.class) break
+    seen.add(next.class)
+    chain.unshift(next)
+    current = next.class
+  }
+  return chain
 }
 
 export default function ClassPage() {
@@ -21,15 +44,31 @@ export default function ClassPage() {
   const [cls, setCls] = useState<Record<string, unknown> | null>(null)
   const [subs, setSubs] = useState<ClassResult[]>([])
   const [supers, setSupers] = useState<ClassResult[]>([])
+  const [ancestors, setAncestors] = useState<ClassResult[]>([])
   const [err, setErr] = useState('')
+  const [copied, setCopied] = useState('')
+
+  const label = cls ? (asList(cls.label)[0] || decodedIri.split(/[#/]/).pop() || decodedIri) : ''
+  useDocumentTitle(label || undefined, id?.toUpperCase())
 
   useEffect(() => {
     if (!id || !decodedIri) return
-    getClass(decodedIri, id).then(d => setCls(d as unknown as Record<string, unknown>)).catch(() => setErr('Class not found'))
+    getClass(decodedIri, id)
+      .then(d => { setCls(d as unknown as Record<string, unknown>); setErr('') })
+      .catch(() => setErr('Class not found'))
     const q = `<${decodedIri}>`
     dlQuery(q, 'subclass', id, true).then(d => setSubs(d.result?.slice(0, 100) || [])).catch(() => {})
     dlQuery(q, 'superclass', id, true).then(d => setSupers(d.result?.slice(0, 100) || [])).catch(() => {})
+    ancestorChain(decodedIri, id).then(setAncestors).catch(() => setAncestors([]))
   }, [id, decodedIri])
+
+  async function copy(text: string, which: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(which)
+      setTimeout(() => setCopied(''), 1500)
+    } catch { /* clipboard unavailable */ }
+  }
 
   if (err) return <div className="max-w-4xl mx-auto px-4 py-8 text-red-500">{err}</div>
   if (!cls) return (
@@ -44,7 +83,6 @@ export default function ClassPage() {
     </div>
   )
 
-  const label = asList(cls.label)[0] || decodedIri.split(/[#/]/).pop() || decodedIri
   const definitions = asList(cls.definition)
   const synonyms = asList(cls.synonyms)
   const subClassOf = asList(cls.SubClassOf).map(stripHtml)
@@ -56,11 +94,18 @@ export default function ClassPage() {
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6">
-      {/* Breadcrumb */}
-      <nav className="text-xs text-gray-400 mb-4 flex items-center gap-1">
+      {/* Breadcrumb with path-to-root */}
+      <nav className="text-xs text-gray-400 mb-4 flex items-center gap-1 flex-wrap">
         <Link to="/" className="hover:text-indigo-600">Home</Link>
         <span>/</span>
         <Link to={`/ontology/${id}`} className="hover:text-indigo-600">{id?.toUpperCase()}</Link>
+        {ancestors.map(a => (
+          <span key={a.class} className="flex items-center gap-1">
+            <span>/</span>
+            <Link to={`/ontology/${id}/class/${encodeURIComponent(a.class)}`}
+              className="hover:text-indigo-600 max-w-[160px] truncate">{labelOf(a)}</Link>
+          </span>
+        ))}
         <span>/</span>
         <span className="text-gray-600">{label}</span>
       </nav>
@@ -74,7 +119,17 @@ export default function ClassPage() {
             {id?.toUpperCase()}
           </Link>
         </div>
-        <p className="text-xs text-gray-400 font-mono break-all mb-3">{decodedIri}</p>
+        <div className="flex items-center gap-2 mb-3 flex-wrap">
+          <p className="text-xs text-gray-400 font-mono break-all flex-1 min-w-0">{decodedIri}</p>
+          <button onClick={() => copy(decodedIri, 'iri')}
+            className="text-xs px-2 py-1 border border-gray-200 rounded hover:border-indigo-400 hover:text-indigo-600 shrink-0">
+            {copied === 'iri' ? 'Copied!' : 'Copy IRI'}
+          </button>
+          <button onClick={() => copy(window.location.href, 'link')}
+            className="text-xs px-2 py-1 border border-gray-200 rounded hover:border-indigo-400 hover:text-indigo-600 shrink-0">
+            {copied === 'link' ? 'Copied!' : 'Copy link'}
+          </button>
+        </div>
 
         {/* OBO ID */}
         {cls.oboid ? (

--- a/central_server/frontend/src/pages/DLQueryPage.tsx
+++ b/central_server/frontend/src/pages/DLQueryPage.tsx
@@ -1,33 +1,69 @@
-import { useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { dlQuery, listOntologies } from '../api/client'
 import type { ClassResult, OntologySummary } from '../api/types'
 import OWLExpression from '../components/OWLExpression'
+import Combobox from '../components/Combobox'
+import StateMessage from '../components/StateMessage'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+const PAGE = 100
 
 export default function DLQueryPage() {
-  const [query, setQuery] = useState('')
-  const [type, setType] = useState('subeq')
-  const [ontology, setOntology] = useState('')
+  const [params, setParams] = useSearchParams()
+  const [query, setQuery] = useState(params.get('q') || '')
+  const [type, setType] = useState(params.get('type') || 'subeq')
+  const [ontology, setOntology] = useState(params.get('ontology') || '')
+  const [direct, setDirect] = useState(params.get('direct') === '1')
   const [results, setResults] = useState<ClassResult[]>([])
   const [time, setTime] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [ontologies, setOntologies] = useState<OntologySummary[]>([])
+  const [limit, setLimit] = useState(PAGE)
+  const didInitial = useRef(false)
+
+  useDocumentTitle('DL Query')
 
   useEffect(() => {
     listOntologies().then(o => setOntologies(o.filter(x => x.status === 'online'))).catch(() => {})
   }, [])
 
+  const options = useMemo(
+    () => ontologies.map(o => ({ value: o.id, label: o.id.toUpperCase(), hint: o.title })),
+    [ontologies],
+  )
+
+  function execute(q: string, t: string, ont: string, dir: boolean) {
+    if (!q.trim()) return
+    setLoading(true)
+    setError('')
+    setLimit(PAGE)
+    dlQuery(q, t, ont || undefined, dir)
+      .then(d => { setResults(d.result || []); setTime(d.time) })
+      .catch(err => { setError(err instanceof Error ? err.message : 'Query failed'); setResults([]); setTime(null) })
+      .finally(() => setLoading(false))
+  }
+
+  // Run automatically when arriving with a query in the URL (shared link)
+  useEffect(() => {
+    if (didInitial.current) return
+    didInitial.current = true
+    if (params.get('q')) execute(params.get('q')!, type, ontology, direct)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   function run(e: React.FormEvent) {
     e.preventDefault()
     if (!query.trim()) return
-    setLoading(true)
-    setError('')
-    dlQuery(query, type, ontology || undefined)
-      .then(d => { setResults(d.result || []); setTime(d.time) })
-      .catch(err => { setError(err.message); setResults([]) })
-      .finally(() => setLoading(false))
+    const next: Record<string, string> = { q: query, type }
+    if (ontology) next.ontology = ontology
+    if (direct) next.direct = '1'
+    setParams(next)
+    execute(query, type, ontology, direct)
   }
+
+  const shown = results.slice(0, limit)
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6">
@@ -46,7 +82,6 @@ export default function DLQueryPage() {
             rows={3}
             className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 focus:outline-none resize-none"
           />
-          {/* Live preview */}
           {query.trim() && (
             <div className="mt-2 px-3 py-2 bg-gray-50 rounded-lg border border-gray-100">
               <span className="text-[10px] text-gray-400 uppercase tracking-wider">Preview: </span>
@@ -66,16 +101,22 @@ export default function DLQueryPage() {
               <option value="equivalent">Equivalent</option>
             </select>
           </div>
-          <div className="min-w-[200px]">
+          <div className="min-w-[240px]">
             <label className="block text-xs text-gray-500 mb-1">Ontology (optional)</label>
-            <select value={ontology} onChange={e => setOntology(e.target.value)}
-              className="px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white w-full">
-              <option value="">All ontologies</option>
-              {ontologies.map(o => (
-                <option key={o.id} value={o.id}>{o.id.toUpperCase()}{o.title ? ` — ${o.title}` : ''}</option>
-              ))}
-            </select>
+            <Combobox
+              options={options}
+              value={ontology}
+              onChange={setOntology}
+              allLabel="All ontologies"
+              placeholder="Search ontologies…"
+            />
           </div>
+          <label className="flex items-center gap-2 text-sm text-gray-600 pb-2 cursor-pointer select-none"
+            title="Return only direct sub/superclasses instead of the full inferred set">
+            <input type="checkbox" checked={direct} onChange={e => setDirect(e.target.checked)}
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-400" />
+            Direct only
+          </label>
           <button type="submit" disabled={loading}
             className="px-6 py-2 bg-indigo-600 text-white rounded-lg text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors">
             {loading ? 'Running...' : 'Run Query'}
@@ -93,18 +134,19 @@ export default function DLQueryPage() {
         </div>
       </form>
 
-      {error && <div className="text-red-600 text-sm mb-4 bg-red-50 p-3 rounded-lg border border-red-200">{error}</div>}
+      {error && <StateMessage kind="error" title="Query failed" detail={error} />}
 
-      {time !== null && (
+      {!error && time !== null && (
         <p className="text-sm text-gray-500 mb-3">
           <span className="font-semibold text-gray-700">{results.length}</span> results in{' '}
           <span className="font-semibold text-gray-700">{time}</span> ms
+          {direct && <span className="ml-2 text-xs text-gray-400">(direct only)</span>}
         </p>
       )}
 
       {results.length > 0 && (
         <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden divide-y divide-gray-100">
-          {results.map((c, i) => {
+          {shown.map((c, i) => {
             const lbl = Array.isArray(c.label) ? c.label[0] : c.label
             const ont = c.ontology || '?'
             return (
@@ -123,6 +165,14 @@ export default function DLQueryPage() {
               </div>
             )
           })}
+          {shown.length < results.length && (
+            <div className="px-4 py-3 text-center">
+              <button onClick={() => setLimit(l => l + PAGE)}
+                className="text-sm text-indigo-600 hover:text-indigo-800 font-medium">
+                Show more ({results.length - shown.length} remaining)
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/central_server/frontend/src/pages/Home.tsx
+++ b/central_server/frontend/src/pages/Home.tsx
@@ -1,30 +1,41 @@
-import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { listOntologies, getStats } from '../api/client'
 import type { OntologySummary, StatsAggregate } from '../api/types'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import SearchBox from '../components/SearchBox'
+import StateMessage from '../components/StateMessage'
+
+const PAGE = 100
 
 export default function Home() {
   const [ontologies, setOntologies] = useState<OntologySummary[]>([])
   const [stats, setStats] = useState<StatsAggregate | null>(null)
-  const [q, setQ] = useState('')
+  const [loadErr, setLoadErr] = useState('')
+  const [loading, setLoading] = useState(true)
   const [filter, setFilter] = useState('')
   const [sortCol, setSortCol] = useState<'id' | 'title' | 'status'>('id')
   const [sortAsc, setSortAsc] = useState(true)
-  const nav = useNavigate()
+  const [limit, setLimit] = useState(PAGE)
 
-  useEffect(() => {
-    listOntologies().then(setOntologies).catch(() => {})
-    getStats().then(setStats).catch(() => {})
+  useDocumentTitle('Ontologies')
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setLoadErr('')
+    Promise.all([listOntologies(), getStats().catch(() => null)])
+      .then(([onts, st]) => { setOntologies(onts); setStats(st) })
+      .catch(e => setLoadErr(e instanceof Error ? e.message : 'Failed to load ontologies'))
+      .finally(() => setLoading(false))
   }, [])
 
-  function onSearch(e: React.FormEvent) {
-    e.preventDefault()
-    if (q.trim()) nav(`/search?q=${encodeURIComponent(q.trim())}`)
-  }
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- load() toggles loading before fetching; intentional
+  useEffect(() => { load() }, [load])
 
   function toggleSort(col: 'id' | 'title' | 'status') {
     if (sortCol === col) setSortAsc(!sortAsc)
     else { setSortCol(col); setSortAsc(true) }
+    setLimit(PAGE)
   }
 
   const filtered = (filter
@@ -33,8 +44,6 @@ export default function Home() {
         (o.title || '').toLowerCase().includes(filter.toLowerCase()))
     : ontologies
   ).slice().sort((a, b) => {
-    // Offline ontologies always sort after online ones, regardless of
-    // the primary sort column or direction.
     const aOffline = a.status === 'online' ? 0 : 1
     const bOffline = b.status === 'online' ? 0 : 1
     if (aOffline !== bOffline) return aOffline - bOffline
@@ -47,6 +56,7 @@ export default function Home() {
   })
 
   const online = ontologies.filter(o => o.status === 'online')
+  const shown = filtered.slice(0, limit)
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
@@ -54,18 +64,11 @@ export default function Home() {
       <div className="text-center mb-10">
         <h1 className="text-4xl font-extrabold text-gray-900 mb-2 tracking-tight">AberOWL</h1>
         <p className="text-gray-500 mb-6 text-lg">Ontology Repository &amp; OWL Reasoning Services</p>
-        <form onSubmit={onSearch} className="max-w-xl mx-auto flex gap-2">
-          <input
-            value={q}
-            onChange={e => setQ(e.target.value)}
-            placeholder="Search for classes across all ontologies..."
-            className="flex-1 px-4 py-3 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 shadow-sm"
-          />
-          <button type="submit"
-            className="px-6 py-3 bg-indigo-600 text-white rounded-xl text-sm font-semibold hover:bg-indigo-700 shadow-sm transition-colors">
-            Search
-          </button>
-        </form>
+        <SearchBox
+          className="max-w-xl mx-auto"
+          placeholder="Search for classes across all ontologies…"
+          inputClassName="w-full px-4 py-3 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 shadow-sm"
+        />
         <div className="flex justify-center gap-4 mt-4">
           <Link to="/dlquery" className="text-sm text-indigo-600 hover:text-indigo-800 font-medium">DL Query</Link>
           <span className="text-gray-300">|</span>
@@ -100,58 +103,70 @@ export default function Home() {
         </h2>
         <input
           value={filter}
-          onChange={e => setFilter(e.target.value)}
+          onChange={e => { setFilter(e.target.value); setLimit(PAGE) }}
           placeholder="Filter ontologies..."
           className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm w-56 focus:ring-2 focus:ring-indigo-400 focus:outline-none"
         />
       </div>
-      <div className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm">
-        <table className="w-full text-sm">
-          <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wider select-none">
-            <tr>
-              {([['id', 'ID', ''], ['title', 'Name', ''], ['status', 'Status', 'text-center w-20']] as const).map(([col, label, cls]) => (
-                <th key={col}
-                  className={`px-4 py-3 cursor-pointer hover:text-gray-700 transition-colors ${cls}`}
-                  onClick={() => toggleSort(col)}>
-                  {label} {sortCol === col ? (sortAsc ? '▲' : '▼') : ''}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {filtered.slice(0, 200).map(o => (
-              <tr key={o.id} className="hover:bg-indigo-50/30 transition-colors">
-                <td className="px-4 py-2.5">
-                  <Link to={`/ontology/${o.id}`} className="text-indigo-600 font-semibold hover:underline">
-                    {o.id.toUpperCase()}
-                  </Link>
-                </td>
-                <td className="px-4 py-2.5 text-gray-700">{o.title || <span className="text-gray-400 italic">—</span>}</td>
-                <td className="px-4 py-2.5 text-center">
-                  <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-                    o.status === 'online'
-                      ? 'bg-emerald-100 text-emerald-700'
-                      : 'bg-gray-100 text-gray-500'
-                  }`}>
-                    <span className={`w-1.5 h-1.5 rounded-full ${
-                      o.status === 'online' ? 'bg-emerald-500' : 'bg-gray-400'
-                    }`} />
-                    {o.status === 'online' ? 'Online' : 'Offline'}
-                  </span>
-                </td>
+
+      {loadErr ? (
+        <StateMessage kind="error" title="Could not load ontologies" detail={loadErr} onRetry={load} />
+      ) : loading ? (
+        <div className="bg-white border border-gray-200 rounded-xl p-8 text-center text-sm text-gray-400">Loading…</div>
+      ) : (
+        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wider select-none">
+              <tr>
+                {([['id', 'ID', ''], ['title', 'Name', ''], ['status', 'Status', 'text-center w-20']] as const).map(([col, label, cls]) => (
+                  <th key={col}
+                    className={`px-4 py-3 cursor-pointer hover:text-gray-700 transition-colors ${cls}`}
+                    onClick={() => toggleSort(col)}>
+                    {label} {sortCol === col ? (sortAsc ? '▲' : '▼') : ''}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-        {filtered.length === 0 && (
-          <div className="px-4 py-8 text-center text-sm text-gray-400">No ontologies match your filter.</div>
-        )}
-        {filtered.length > 200 && (
-          <div className="px-4 py-2 text-xs text-gray-400 text-center border-t">
-            Showing 200 of {filtered.length}
-          </div>
-        )}
-      </div>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {shown.map(o => (
+                <tr key={o.id} className="hover:bg-indigo-50/30 transition-colors">
+                  <td className="px-4 py-2.5">
+                    <Link to={`/ontology/${o.id}`} className="text-indigo-600 font-semibold hover:underline">
+                      {o.id.toUpperCase()}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2.5 text-gray-700">{o.title || <span className="text-gray-400 italic">—</span>}</td>
+                  <td className="px-4 py-2.5 text-center">
+                    <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
+                      o.status === 'online'
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-gray-100 text-gray-500'
+                    }`}>
+                      <span className={`w-1.5 h-1.5 rounded-full ${
+                        o.status === 'online' ? 'bg-emerald-500' : 'bg-gray-400'
+                      }`} />
+                      {o.status === 'online' ? 'Online' : 'Offline'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {filtered.length === 0 && (
+            <div className="px-4 py-8 text-center text-sm text-gray-400">No ontologies match your filter.</div>
+          )}
+          {shown.length < filtered.length && (
+            <div className="px-4 py-3 text-center border-t border-gray-100">
+              <button
+                onClick={() => setLimit(l => l + PAGE)}
+                className="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+              >
+                Show more ({filtered.length - shown.length} remaining)
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/central_server/frontend/src/pages/OntologyPage.tsx
+++ b/central_server/frontend/src/pages/OntologyPage.tsx
@@ -1,43 +1,76 @@
-import { useEffect, useState, useCallback } from 'react'
-import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { getOntology, getClass, dlQuery } from '../api/client'
 import type { OntologyDetail, ClassResult } from '../api/types'
 import TreeNode from '../components/TreeNode'
 import OWLExpression from '../components/OWLExpression'
+import StateMessage from '../components/StateMessage'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 type Tab = 'browse' | 'query' | 'info'
+const TABS: Tab[] = ['browse', 'query', 'info']
 
 function asList(v: unknown): string[] {
   if (!v) return []
-  if (Array.isArray(v)) return v
+  if (Array.isArray(v)) return v.map(String)
   return [String(v)]
+}
+
+function labelOf(c: ClassResult): string {
+  return (Array.isArray(c.label) ? c.label[0] : c.label) || ''
+}
+
+/** Walk the direct-superclass chain to build an ancestor IRI set for tree expansion. */
+async function ancestorPath(iri: string, ontologyId: string): Promise<Set<string>> {
+  const path = new Set<string>()
+  let current = iri
+  for (let i = 0; i < 50; i++) {
+    if (path.has(current)) break
+    const q = current.startsWith('http') ? `<${current}>` : current
+    const supers = await dlQuery(q, 'superclass', ontologyId, true)
+      .then(d => d.result || []).catch(() => [])
+    const next = supers.find(s => s.class && !/owl#Thing$/.test(s.class))
+    if (!next?.class) break
+    path.add(next.class)
+    current = next.class
+  }
+  return path
 }
 
 export default function OntologyPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const [params, setParams] = useSearchParams()
   const [ont, setOnt] = useState<OntologyDetail | null>(null)
-  const [tab, setTab] = useState<Tab>('browse')
-  const [rootClasses, setRootClasses] = useState<ClassResult[] | null>(null)
   const [err, setErr] = useState('')
 
-  // Selected class detail (OLS-style: click tree node → show details on right)
-  const [selectedIri, setSelectedIri] = useState<string | null>(null)
+  const tabParam = params.get('tab') as Tab | null
+  const tab: Tab = tabParam && TABS.includes(tabParam) ? tabParam : 'browse'
+  const selectedIri = params.get('class')
+
+  const [rootClasses, setRootClasses] = useState<ClassResult[] | null>(null)
+  const [expandPath, setExpandPath] = useState<Set<string> | undefined>()
+
+  // Selected class detail
   const [selectedClass, setSelectedClass] = useState<Record<string, unknown> | null>(null)
   const [selectedSubs, setSelectedSubs] = useState<ClassResult[]>([])
   const [selectedSupers, setSelectedSupers] = useState<ClassResult[]>([])
   const [detailLoading, setDetailLoading] = useState(false)
 
-  // DL query state
-  const [queryText, setQueryText] = useState('')
-  const [queryType, setQueryType] = useState('subeq')
+  // DL query state (in-ontology tab)
+  const [queryText, setQueryText] = useState(params.get('q') || '')
+  const [queryType, setQueryType] = useState(params.get('type') || 'subeq')
+  const [queryDirect, setQueryDirect] = useState(params.get('direct') === '1')
   const [queryResults, setQueryResults] = useState<ClassResult[]>([])
   const [queryTime, setQueryTime] = useState<number | null>(null)
   const [queryLoading, setQueryLoading] = useState(false)
+  const [queryError, setQueryError] = useState('')
+
+  useDocumentTitle(ont?.title || ont?.ontology?.toUpperCase() || id?.toUpperCase())
 
   useEffect(() => {
     if (!id) return
-    getOntology(id).then(setOnt).catch(() => setErr('Ontology not found'))
+    getOntology(id).then(o => { setOnt(o); setErr('') }).catch(() => setErr('Ontology not found'))
   }, [id])
 
   useEffect(() => {
@@ -45,35 +78,36 @@ export default function OntologyPage() {
     dlQuery('<http://www.w3.org/2002/07/owl#Thing>', 'subclass', id, true)
       .then(d => {
         const results = d.result || []
-        // Sort: non-deprecated first, deprecated last, alphabetical within each group
-        results.sort((a: ClassResult, b: ClassResult) => {
-          const aObs = a.deprecated || /^obsolete /i.test(Array.isArray(a.label) ? a.label[0] || '' : a.label || '') ? 1 : 0
-          const bObs = b.deprecated || /^obsolete /i.test(Array.isArray(b.label) ? b.label[0] || '' : b.label || '') ? 1 : 0
+        results.sort((a, b) => {
+          const aObs = a.deprecated || /^obsolete /i.test(labelOf(a)) ? 1 : 0
+          const bObs = b.deprecated || /^obsolete /i.test(labelOf(b)) ? 1 : 0
           if (aObs !== bObs) return aObs - bObs
-          const aL = (Array.isArray(a.label) ? a.label[0] : a.label) || ''
-          const bL = (Array.isArray(b.label) ? b.label[0] : b.label) || ''
-          return aL.localeCompare(bL)
+          return labelOf(a).localeCompare(labelOf(b))
         })
         setRootClasses(results)
       })
       .catch(() => setRootClasses([]))
   }, [id, tab, rootClasses])
 
-  // Load class details when a tree node is selected
-  const onSelectClass = useCallback((iri: string) => {
-    if (!id || iri === selectedIri) return
-    setSelectedIri(iri)
-    setSelectedClass(null)
-    setSelectedSubs([])
-    setSelectedSupers([])
+  const setTab = useCallback((t: Tab) => {
+    const next = new URLSearchParams(params)
+    next.set('tab', t)
+    setParams(next, { replace: true })
+  }, [params, setParams])
+
+  // Load class details whenever the selected IRI (from URL) changes.
+  // The synchronous reset is intentional: clear the previous class's detail
+  // immediately so the panel shows a loading state, not stale data.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional immediate clear (see comment above)
+    setSelectedClass(null); setSelectedSubs([]); setSelectedSupers([])
+    if (!id || !selectedIri) return
     setDetailLoading(true)
-
-    const q = iri.startsWith('http') ? `<${iri}>` : iri
-
+    const q = selectedIri.startsWith('http') ? `<${selectedIri}>` : selectedIri
     Promise.all([
-      getClass(iri, id).catch(() => null),
-      dlQuery(q, 'subclass', id, true).then(d => d.result?.slice(0, 50) || []).catch(() => []),
-      dlQuery(q, 'superclass', id, true).then(d => d.result?.slice(0, 50) || []).catch(() => []),
+      getClass(selectedIri, id).catch(() => null),
+      dlQuery(q, 'subclass', id, true).then(d => d.result || []).catch(() => []),
+      dlQuery(q, 'superclass', id, true).then(d => d.result || []).catch(() => []),
     ]).then(([cls, subs, supers]) => {
       setSelectedClass(cls as Record<string, unknown> | null)
       setSelectedSubs(subs)
@@ -82,22 +116,38 @@ export default function OntologyPage() {
     })
   }, [id, selectedIri])
 
+  // Restore tree expansion for a deep-linked class
+  useEffect(() => {
+    if (!id || !selectedIri || rootClasses === null) return
+    ancestorPath(selectedIri, id).then(setExpandPath)
+  }, [id, selectedIri, rootClasses])
+
+  const onSelectClass = useCallback((iri: string) => {
+    const next = new URLSearchParams(params)
+    next.set('tab', 'browse')
+    next.set('class', iri)
+    setParams(next, { replace: false })
+  }, [params, setParams])
+
   function runQuery(e: React.FormEvent) {
     e.preventDefault()
     if (!queryText.trim() || !id) return
+    const next = new URLSearchParams(params)
+    next.set('tab', 'query'); next.set('q', queryText); next.set('type', queryType)
+    if (queryDirect) next.set('direct', '1'); else next.delete('direct')
+    setParams(next, { replace: true })
     setQueryLoading(true)
-    dlQuery(queryText, queryType, id)
+    setQueryError('')
+    dlQuery(queryText, queryType, id, queryDirect)
       .then(d => { setQueryResults(d.result || []); setQueryTime(d.time) })
-      .catch(() => setQueryResults([]))
+      .catch(e => { setQueryError(e instanceof Error ? e.message : 'Query failed'); setQueryResults([]); setQueryTime(null) })
       .finally(() => setQueryLoading(false))
   }
 
-  if (err) return <div className="max-w-5xl mx-auto px-4 py-8 text-red-500">{err}</div>
+  if (err) return <div className="max-w-5xl mx-auto px-4 py-8"><StateMessage kind="error" title={err} /></div>
   if (!ont) return (
     <div className="max-w-5xl mx-auto px-4 py-12 flex justify-center">
-      <div className="flex items-center gap-3 text-gray-400">
-        <Spinner /> Loading ontology...
-      </div>
+      <div className="flex items-center gap-3 text-gray-400"><Spinner /> Loading ontology...</div>
     </div>
   )
 
@@ -147,9 +197,7 @@ export default function OntologyPage() {
             key={t.key}
             onClick={() => setTab(t.key)}
             className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              tab === t.key
-                ? 'border-indigo-600 text-indigo-700'
-                : 'border-transparent text-gray-500 hover:text-gray-700'
+              tab === t.key ? 'border-indigo-600 text-indigo-700' : 'border-transparent text-gray-500 hover:text-gray-700'
             }`}
           >
             {t.label}
@@ -157,17 +205,15 @@ export default function OntologyPage() {
         ))}
       </div>
 
-      {/* Browse tab — OLS-style: tree left, details right */}
+      {/* Browse tab */}
       {tab === 'browse' && (
         <div className="flex gap-4" style={{ minHeight: '60vh' }}>
-          {/* Left: Tree */}
           <div className="w-[380px] shrink-0 bg-white border border-gray-200 rounded-lg shadow-sm flex flex-col">
             <div className="px-3 py-2.5 border-b border-gray-100 bg-gray-50/60 rounded-t-lg">
-              <h3 className="text-xs font-semibold text-gray-600 uppercase tracking-wider">
-                Class Hierarchy
-              </h3>
+              <h3 className="text-xs font-semibold text-gray-600 uppercase tracking-wider">Class Hierarchy</h3>
             </div>
-            <div className="p-2 flex-1 overflow-y-auto text-[13px] font-mono max-h-[70vh]">
+            <div role="tree" aria-label="Class hierarchy"
+              className="p-2 flex-1 overflow-y-auto text-[13px] font-mono max-h-[70vh]">
               {rootClasses === null ? (
                 <div className="flex items-center gap-2 text-gray-400 py-4 justify-center">
                   <Spinner /> <span className="text-sm font-sans">Loading...</span>
@@ -176,44 +222,27 @@ export default function OntologyPage() {
                 <p className="text-sm text-gray-400 text-center py-4 font-sans">No root classes</p>
               ) : (
                 rootClasses.map((c, i) => (
-                  <TreeNode
-                    key={c.class || i}
-                    node={c}
-                    ontologyId={id!}
-                    onSelect={onSelectClass}
-                    selectedIri={selectedIri}
-                  />
+                  <TreeNode key={c.class || i} node={c} ontologyId={id!}
+                    onSelect={onSelectClass} selectedIri={selectedIri} expandPath={expandPath} />
                 ))
               )}
             </div>
           </div>
 
-          {/* Right: Class detail panel */}
           <div className="flex-1 min-w-0">
             {!selectedIri ? (
               <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-8 text-center text-gray-400 text-sm h-full flex items-center justify-center">
-                <div>
-                  <div className="text-3xl mb-2 opacity-30">◆</div>
-                  Select a class from the hierarchy to view details
-                </div>
+                <div><div className="text-3xl mb-2 opacity-30">◆</div>Select a class from the hierarchy to view details</div>
               </div>
             ) : detailLoading ? (
               <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-8 flex items-center justify-center h-full">
-                <div className="flex items-center gap-3 text-gray-400">
-                  <Spinner /> Loading class details...
-                </div>
+                <div className="flex items-center gap-3 text-gray-400"><Spinner /> Loading class details...</div>
               </div>
             ) : selectedClass ? (
               <ClassDetailPanel
-                cls={selectedClass}
-                iri={selectedIri}
-                label={selLabel}
-                subs={selectedSubs}
-                supers={selectedSupers}
-                ontologyId={id!}
-                onNavigate={(iri) => {
-                  onSelectClass(iri)
-                }}
+                cls={selectedClass} iri={selectedIri} label={selLabel}
+                subs={selectedSubs} supers={selectedSupers} ontologyId={id!}
+                onNavigate={onSelectClass}
                 onOpenFull={() => navigate(`/ontology/${id}/class/${encodeURIComponent(selectedIri!)}`)}
               />
             ) : (
@@ -232,10 +261,8 @@ export default function OntologyPage() {
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1.5">Manchester OWL Syntax Query</label>
               <textarea
-                value={queryText}
-                onChange={e => setQueryText(e.target.value)}
-                placeholder="e.g. 'part of' some 'cell'"
-                rows={2}
+                value={queryText} onChange={e => setQueryText(e.target.value)}
+                placeholder="e.g. 'part of' some 'cell'" rows={2}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 focus:outline-none resize-none"
               />
               {queryText.trim() && (
@@ -245,7 +272,7 @@ export default function OntologyPage() {
                 </div>
               )}
             </div>
-            <div className="flex gap-3 items-end">
+            <div className="flex gap-3 items-end flex-wrap">
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Query type</label>
                 <select value={queryType} onChange={e => setQueryType(e.target.value)}
@@ -257,6 +284,12 @@ export default function OntologyPage() {
                   <option value="equivalent">Equivalent</option>
                 </select>
               </div>
+              <label className="flex items-center gap-2 text-sm text-gray-600 pb-2 cursor-pointer select-none"
+                title="Return only direct sub/superclasses">
+                <input type="checkbox" checked={queryDirect} onChange={e => setQueryDirect(e.target.checked)}
+                  className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-400" />
+                Direct only
+              </label>
               <button type="submit" disabled={queryLoading}
                 className="px-5 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors">
                 {queryLoading ? 'Running...' : 'Run Query'}
@@ -264,10 +297,12 @@ export default function OntologyPage() {
             </div>
           </form>
 
-          {queryTime !== null && (
+          {queryError && <div className="mt-4"><StateMessage kind="error" title="Query failed" detail={queryError} /></div>}
+          {!queryError && queryTime !== null && (
             <p className="text-sm text-gray-500 mt-4 mb-2">
               <span className="font-medium text-gray-700">{queryResults.length}</span> results in{' '}
               <span className="font-medium text-gray-700">{queryTime}</span> ms
+              {queryDirect && <span className="ml-2 text-xs text-gray-400">(direct only)</span>}
             </p>
           )}
           {queryResults.length > 0 && (
@@ -276,7 +311,7 @@ export default function OntologyPage() {
                 <div key={c.class || i} className="py-2 px-3 flex items-center gap-2 text-sm hover:bg-gray-50">
                   <Link to={`/ontology/${id}/class/${encodeURIComponent(c.class)}`}
                     className="text-indigo-600 hover:underline truncate font-medium">
-                    {Array.isArray(c.label) ? c.label[0] : c.label}
+                    {labelOf(c)}
                   </Link>
                   <span className="text-xs text-gray-400 truncate">{c.class}</span>
                 </div>
@@ -287,30 +322,7 @@ export default function OntologyPage() {
       )}
 
       {/* Info tab */}
-      {tab === 'info' && (
-        <div className="bg-white border border-gray-200 rounded-lg p-5 shadow-sm">
-          <h3 className="text-sm font-semibold text-gray-700 mb-4">Ontology Metadata</h3>
-          <dl className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-sm">
-            {[
-              ['Ontology ID', ont.ontology],
-              ['Title', ont.title],
-              ['Version', ont.version_info],
-              ['License', ont.license],
-              ['Home Page', ont.home_page],
-            ].filter(([, v]) => v).map(([k, v]) => (
-              <div key={k as string} className="border-b border-gray-100 pb-2">
-                <dt className="text-gray-500 text-xs uppercase tracking-wider mb-0.5">{k}</dt>
-                <dd className="text-gray-800">
-                  {String(v).startsWith('http') ? (
-                    <a href={v as string} target="_blank" rel="noreferrer"
-                      className="text-indigo-600 hover:underline break-all">{v}</a>
-                  ) : v}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      )}
+      {tab === 'info' && <MetadataPanel ont={ont} id={id} />}
     </div>
   )
 }
@@ -336,6 +348,80 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
+function MetadataPanel({ ont, id }: { ont: OntologyDetail; id?: string }) {
+  const contact = useMemo(() => {
+    const c = ont.contact
+    if (!c) return ''
+    if (typeof c === 'string') return c
+    if (Array.isArray(c)) return c.map(x => typeof x === 'string' ? x : JSON.stringify(x)).join(', ')
+    const obj = c as Record<string, unknown>
+    return [obj.label, obj.email].filter(Boolean).join(' — ') || JSON.stringify(c)
+  }, [ont.contact])
+
+  const fields: Array<[string, unknown]> = [
+    ['Ontology ID', ont.ontology || id],
+    ['Title', ont.title],
+    ['Description', ont.description],
+    ['Version', ont.version_info],
+    ['Version IRI', ont.version_iri],
+    ['License', ont.license],
+    ['Home Page', ont.home_page],
+    ['Documentation', ont.documentation],
+    ['Publication', ont.publication],
+    ['Creators', ont.creators?.length ? ont.creators.join(', ') : ''],
+    ['Contact', contact],
+    ['Default Namespace', ont.default_namespace],
+    ['OBO Format Version', ont.obo_format_version],
+    ['Reasoner', ont.reasoner_type],
+    ['DL Expressivity', ont.dl_expressivity],
+  ]
+
+  const counts: Array<[string, number | undefined]> = [
+    ['Classes', ont.class_count],
+    ['Object Properties', ont.object_property_count],
+    ['Data Properties', ont.data_property_count],
+    ['Annotation Properties', ont.annotation_property_count],
+    ['Individuals', ont.individual_count],
+    ['Axioms (total)', ont.axiom_count],
+    ['Logical Axioms', ont.logical_axiom_count],
+    ['TBox Axioms', ont.tbox_axiom_count],
+    ['ABox Axioms', ont.abox_axiom_count],
+    ['RBox Axioms', ont.rbox_axiom_count],
+    ['Declaration Axioms', ont.declaration_axiom_count],
+  ]
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-5 shadow-sm space-y-6">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 mb-4">Ontology Metadata</h3>
+        <dl className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+          {fields.filter(([, v]) => v != null && v !== '').map(([k, v]) => (
+            <div key={k} className="border-b border-gray-100 pb-2">
+              <dt className="text-gray-500 text-xs uppercase tracking-wider mb-0.5">{k}</dt>
+              <dd className="text-gray-800 break-words">
+                {String(v).startsWith('http') ? (
+                  <a href={String(v)} target="_blank" rel="noreferrer" className="text-indigo-600 hover:underline break-all">{String(v)}</a>
+                ) : String(v)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 mb-3">Counts</h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {counts.filter(([, v]) => v != null).map(([k, v]) => (
+            <div key={k} className="bg-gray-50 border border-gray-100 rounded-lg p-2.5">
+              <div className="text-base font-semibold text-gray-900">{(v ?? 0).toLocaleString()}</div>
+              <div className="text-[10px] text-gray-500 uppercase tracking-wider">{k}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 interface ClassDetailPanelProps {
   cls: Record<string, unknown>
   iri: string
@@ -348,6 +434,7 @@ interface ClassDetailPanelProps {
 }
 
 function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFull }: ClassDetailPanelProps) {
+  const [subLimit, setSubLimit] = useState(50)
   const definitions = asList(cls.definition)
   const synonyms = asList(cls.synonyms)
   const subClassOf = asList(cls.SubClassOf)
@@ -360,33 +447,25 @@ function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFul
 
   return (
     <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-y-auto max-h-[75vh]">
-      {/* Header */}
       <div className="px-5 py-4 border-b border-gray-100 bg-gray-50/50">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
             <h2 className="text-lg font-bold text-gray-900 break-words">{label}</h2>
             <p className="text-xs text-gray-400 font-mono break-all mt-0.5">{iri}</p>
-            {cls.oboid ? (
-              <span className="text-xs text-gray-500 font-mono">{String(cls.oboid as string)}</span>
-            ) : null}
+            {cls.oboid ? <span className="text-xs text-gray-500 font-mono">{String(cls.oboid)}</span> : null}
           </div>
           <button onClick={onOpenFull}
             className="text-xs text-indigo-600 hover:text-indigo-800 shrink-0 px-2 py-1 border border-indigo-200 rounded hover:bg-indigo-50 transition-colors"
-            title="Open full class page">
-            Full page →
-          </button>
+            title="Open full class page">Full page →</button>
         </div>
       </div>
 
       <div className="p-5 space-y-5">
-        {/* Description */}
         {definitions.length > 0 && (
           <Section title="Description">
             {definitions.map((d, i) => <p key={i} className="text-sm text-gray-700 leading-relaxed">{d}</p>)}
           </Section>
         )}
-
-        {/* Synonyms */}
         {synonyms.length > 0 && (
           <Section title="Synonyms">
             <div className="flex flex-wrap gap-1.5">
@@ -396,8 +475,6 @@ function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFul
             </div>
           </Section>
         )}
-
-        {/* Hierarchy */}
         <Section title="Hierarchy">
           {supers.length > 0 && (
             <div className="mb-2">
@@ -407,8 +484,7 @@ function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFul
                   <li key={i}>
                     <button onClick={() => onNavigate(c.class)}
                       className="text-sm text-indigo-600 hover:underline flex items-center gap-1.5 text-left">
-                      <span className="text-gray-300 text-xs">▲</span>
-                      {Array.isArray(c.label) ? c.label[0] : c.label}
+                      <span className="text-gray-300 text-xs">▲</span>{labelOf(c)}
                     </button>
                   </li>
                 ))}
@@ -419,16 +495,21 @@ function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFul
             <div>
               <span className="text-[10px] text-gray-400 uppercase tracking-wider">Subclasses ({subs.length})</span>
               <ul className="mt-1 space-y-0.5 max-h-40 overflow-y-auto">
-                {subs.map((c, i) => (
+                {subs.slice(0, subLimit).map((c, i) => (
                   <li key={i}>
                     <button onClick={() => onNavigate(c.class)}
                       className="text-sm text-indigo-600 hover:underline flex items-center gap-1.5 text-left">
-                      <span className="text-gray-300 text-xs">▼</span>
-                      {Array.isArray(c.label) ? c.label[0] : c.label}
+                      <span className="text-gray-300 text-xs">▼</span>{labelOf(c)}
                     </button>
                   </li>
                 ))}
               </ul>
+              {subs.length > subLimit && (
+                <button onClick={() => setSubLimit(l => l + 100)}
+                  className="mt-1 text-xs text-indigo-600 hover:underline">
+                  Show all {subs.length}
+                </button>
+              )}
             </div>
           )}
           {supers.length === 0 && subs.length === 0 && (
@@ -436,22 +517,14 @@ function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFul
           )}
         </Section>
 
-        {/* Axioms with syntax highlighting */}
         {(subClassOf.length > 0 || equivalent.length > 0 || disjoint.length > 0) && (
           <Section title="Logical Axioms">
-            {subClassOf.length > 0 && (
-              <AxiomBlock label="SubClassOf" axioms={subClassOf} />
-            )}
-            {equivalent.length > 0 && (
-              <AxiomBlock label="EquivalentTo" axioms={equivalent} />
-            )}
-            {disjoint.length > 0 && (
-              <AxiomBlock label="DisjointWith" axioms={disjoint} />
-            )}
+            {subClassOf.length > 0 && <AxiomBlock label="SubClassOf" axioms={subClassOf} />}
+            {equivalent.length > 0 && <AxiomBlock label="EquivalentTo" axioms={equivalent} />}
+            {disjoint.length > 0 && <AxiomBlock label="DisjointWith" axioms={disjoint} />}
           </Section>
         )}
 
-        {/* Other annotations */}
         {otherAnnotations.length > 0 && (
           <Section title="Annotations">
             <dl className="text-sm space-y-1.5">
@@ -472,9 +545,7 @@ function ClassDetailPanel({ cls, iri, label, subs, supers, onNavigate, onOpenFul
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 border-b border-gray-100 pb-1">
-        {title}
-      </h3>
+      <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 border-b border-gray-100 pb-1">{title}</h3>
       {children}
     </div>
   )

--- a/central_server/frontend/src/pages/SearchResults.tsx
+++ b/central_server/frontend/src/pages/SearchResults.tsx
@@ -1,23 +1,34 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { searchClasses } from '../api/client'
 import type { ClassResult } from '../api/types'
 import ClassCard from '../components/ClassCard'
+import StateMessage from '../components/StateMessage'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export default function SearchResults() {
   const [params] = useSearchParams()
   const q = params.get('q') || ''
   const [results, setResults] = useState<ClassResult[]>([])
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
-  useEffect(() => {
+  useDocumentTitle(q ? `Search: ${q}` : 'Search')
+
+  const load = useCallback(() => {
     if (!q) return
     setLoading(true)
+    setError('')
+    setExpanded(new Set())
     searchClasses(q, undefined, 200)
       .then(setResults)
-      .catch(() => setResults([]))
+      .catch(e => { setError(e instanceof Error ? e.message : 'Search failed'); setResults([]) })
       .finally(() => setLoading(false))
   }, [q])
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- load() toggles loading before fetching; intentional
+  useEffect(() => { load() }, [load])
 
   // Group by ontology
   const byOnt = new Map<string, ClassResult[]>()
@@ -36,23 +47,36 @@ export default function SearchResults() {
         {loading ? 'Searching...' : `${results.length} results across ${byOnt.size} ontologies`}
       </p>
 
-      {!loading && results.length === 0 && q && (
-        <p className="text-gray-500">No results found.</p>
+      {error && <StateMessage kind="error" title="Search failed" detail={error} onRetry={load} />}
+
+      {!loading && !error && results.length === 0 && q && (
+        <StateMessage title="No results found" detail={`Nothing matched "${q}".`} />
       )}
 
-      {[...byOnt.entries()].map(([ont, items]) => (
-        <div key={ont} className="mb-6">
-          <h2 className="text-sm font-semibold text-gray-700 mb-2 uppercase">{ont} ({items.length})</h2>
-          <div className="grid gap-2 md:grid-cols-2">
-            {items.slice(0, 20).map((c, i) => (
-              <ClassCard key={c.class || i} c={c} />
-            ))}
+      {[...byOnt.entries()].map(([ont, items]) => {
+        const isOpen = expanded.has(ont)
+        const visible = isOpen ? items : items.slice(0, 20)
+        return (
+          <div key={ont} className="mb-6">
+            <h2 className="text-sm font-semibold text-gray-700 mb-2 uppercase">{ont} ({items.length})</h2>
+            <div className="grid gap-2 md:grid-cols-2">
+              {visible.map((c, i) => <ClassCard key={c.class || i} c={c} />)}
+            </div>
+            {items.length > 20 && (
+              <button
+                onClick={() => setExpanded(prev => {
+                  const next = new Set(prev)
+                  if (next.has(ont)) next.delete(ont); else next.add(ont)
+                  return next
+                })}
+                className="text-xs text-indigo-600 hover:underline mt-1"
+              >
+                {isOpen ? 'Show fewer' : `Show all ${items.length} in ${ont}`}
+              </button>
+            )}
           </div>
-          {items.length > 20 && (
-            <p className="text-xs text-gray-400 mt-1">...and {items.length - 20} more in {ont}</p>
-          )}
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/central_server/frontend/src/pages/SparqlPage.tsx
+++ b/central_server/frontend/src/pages/SparqlPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import CodeMirror from '@uiw/react-codemirror'
-import { sql } from '@codemirror/lang-sql'
 import { oneDark } from '@codemirror/theme-one-dark'
 import { rewriteSparql } from '../api/client'
+import { sparql } from '../codemirror/sparqlMode'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 const KNOWN_ENDPOINTS = [
   { label: 'Ontobee', value: 'https://sparql.hegroup.org/sparql' },
@@ -67,6 +68,8 @@ export default function SparqlPage() {
   const [executing, setExecuting] = useState(false)
   const [results, setResults] = useState<SparqlResults | null>(null)
   const [executeError, setExecuteError] = useState('')
+
+  useDocumentTitle('SPARQL')
 
   async function rewrite(): Promise<string | null> {
     setLoading(true)
@@ -171,7 +174,7 @@ export default function SparqlPage() {
           value={query}
           onChange={setQuery}
           height="260px"
-          extensions={[sql()]}
+          extensions={[sparql]}
           theme={oneDark}
         />
       </div>


### PR DESCRIPTION
Implements the web-UI and metadata fixes filed in #16–#29. Frontend typechecks (`tsc -b`), passes ESLint (also fixed 2 pre-existing lint errors), and builds (`npm run build`). Backend changes are syntax/import-checked.

## Frontend (`central_server/frontend`)

| Issue | Change |
|---|---|
| #16 | New metadata panel renders **all** returned fields + an axiom-count grid; `OntologyDetail` type extended. |
| #17 | Ontology tab + selected class live in the URL (`?tab=&class=`); the class tree auto-expands along the ancestor path so a deep link restores the view. |
| #18 | DL Query page **and** in-ontology query tab persist `q/type/ontology/direct` in the URL and auto-run from a shared link. |
| #19 | "Direct only" checkbox on both DL query surfaces (the API already supported `direct`). |
| #20 | Replaced the 800+ item `<select>` with a searchable, keyboard-navigable combobox. |
| #21 | Mobile hamburger nav + drawer. |
| #22 | Debounced class-name autocomplete in the header and hero search (uses the prefix endpoint). |
| #23 | Show-more pagination on home, search (per ontology), DL results, and the class subclass list. |
| #24 | Real error/empty states with retry on home, search, DL query, ontology page. |
| #25 | Class tree gets ARIA tree roles (`tree`/`treeitem`/`group`, `aria-expanded/selected/level`) + arrow-key/Enter navigation. |
| #26 | Per-route `document.title`. |
| #28 | Class page: copy-IRI / copy-link buttons + path-to-root breadcrumb. (Graph visualization left as a follow-up.) |
| #29 | SPARQL editor uses a SPARQL syntax mode instead of SQL highlighting (lightweight inline `StreamLanguage`, no new dependency). |

## Backend

- **#27** `aberowlapi/api/getStatistics.groovy`: report a canonical DL name via `DLExpressivityChecker.expressibleInLanguages()` (e.g. `ALC`) instead of a garbled construct concatenation like `CCINTERI`/`RRESTRCHIN(D)`. Verified against the OWLAPI jar that an ALC ontology returns `[ALC]`.
- **#16** `central_server/app`: enrich registry metadata (`title/description/home_page/license/contact`) from the OBO Foundry registry — previously only `title` was backfilled. Added a **BioPortal metadata intake** (`fetch_bioportal_metadata`) so non-OBO ontologies (e.g. `iso639-2`) get titles/descriptions; it loads in the background at startup and re-applies fallbacks to registered servers. The BioPortal API key is now env-configurable (`BIOPORTAL_API_KEY`).

## Notes / follow-ups
- No live click-through was run (no local central server in the dev env); verification was via typecheck + lint + production build. Worth a smoke test against the beta API before merge.
- `@codemirror/lang-sql` is now unused but left in `package.json` (offline env; safe to prune later).
- #28 graph visualization not included.

Closes #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #29
Addresses #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)