### PR TITLE
fix(central): raise getStatistics refresh probe timeout 10s → 30s

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -316,7 +316,7 @@ async def fetch_and_update_server_metadata(server: Dict[str, Any]):
     logger.info(f"Fetching metadata for {ontology} from {stats_url} (originally {url})")
     try:
         async with aiohttp.ClientSession() as session:
-            async with session.get(stats_url, timeout=10) as response:
+            async with session.get(stats_url, timeout=30) as response:
                 if response.status == 200:
                     stats = await response.json()
                     server.update(stats)


### PR DESCRIPTION
## Problem
Large *flat* ontologies are marked **offline** by the periodic metadata refresh and dropped from `dlquery_all` (which filters `status == "online"`), so they're unreachable via central despite serving fine on their workers.

Measured `getStatistics` times (refresh probe limit is 10s):

| ontology | getStatistics | status |
|---|---|---|
| mesh (~350k cls) | **18.6 s** | offline |
| loinc (~297k cls) | **14.6 s** | offline |
| chebi | 1.7 s | online |
| ncit | 1.2 s | online |

mesh/loinc have ~100k+ classes directly under `owl:Thing`; the stats servlet is O(axioms).

## Fix
Raise the probe `timeout` from 10s → 30s (`fetch_and_update_server_metadata`, main.py:319). Both offenders (18.6s/14.6s) fit under 30s, so they stay online.

This is the minimal fix. The proper fix — **cache `getStatistics` on the worker** so the probe is ~instant — is described in #33.

Closes #33