### PR TITLE
fix(deploy): download MESH as RDF, not CSV (#32)

### DIFF
--- a/deploy/download_ontologies.py
+++ b/deploy/download_ontologies.py
@@ -22,7 +22,9 @@ OBO_URL_TEMPLATE = "http://purl.obolibrary.org/obo/{id}.owl"
 # BioPortal ontologies with known direct download URLs
 BIOPORTAL_URLS = {
     "SNOMEDCT": None,  # Too large / restricted, skip
-    "MESH": "https://data.bioontology.org/ontologies/MESH/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb&download_format=csv",
+    # download_format must be rdf, not csv — BioPortal's CSV export is not OWL and
+    # fails to load on the worker ("Content is not allowed in prolog"). See #32.
+    "MESH": "https://data.bioontology.org/ontologies/MESH/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb&download_format=rdf",
     "NCIT": "https://purl.obolibrary.org/obo/ncit.owl",
     "LOINC": None,  # Restricted
     "ICD10CM": None,  # Restricted


### PR DESCRIPTION
BioPortal `download_format=csv` returns CSV, not OWL — `mesh.owl` then fails to parse (`Content is not allowed in prolog`) and MESH goes offline. Switch to `download_format=rdf`.

Production MESH is already restored as RDF and online; this just prevents the CSV file recurring on the next sync.

Closes #32