### PR TITLE
feat(deploy): purge/exclude 0-class ontologies (#31)

### DIFF
--- a/scripts/plan_distribution.py
+++ b/scripts/plan_distribution.py
@@ -282,10 +282,11 @@ def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]
     pinned = [r for r in records if (r.get("id") or "").lower() in PINNED_GIANTS]
     records = [r for r in records if (r.get("id") or "").lower() not in PINNED_GIANTS]
 
-    # Group records by bucket. Ontologies with 0 / no class data are NOT allocated:
-    # a 0-owl:Class entry is a SKOS/DCAT non-ontology, not something to reason over
-    # (see #31; find/purge them with scripts/purge_zero_class.py). Surface the set
-    # instead of dropping it silently.
+    # Group records by bucket. Ontologies with 0 / no class data can't be sized by
+    # class count, so they're NOT allocated here. 0 owl:Class doesn't mean empty —
+    # SKOS/DCAT entries have an ABox — so these are surfaced for REVIEW (not dropped
+    # silently); scripts/purge_zero_class.py distinguishes truly-empty from ABox-only
+    # (see #31).
     by_bucket: dict[str, list[dict]] = defaultdict(list)
     skipped = []
     for r in records:
@@ -295,7 +296,7 @@ def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]
         by_bucket[class_bucket(r["classes"])].append(r)
     if skipped:
         print(f"  plan: {len(skipped)} ontologies have 0/no classes — not allocated "
-              f"(0-class candidates for purge, see #31): {sorted(skipped)[:20]}"
+              f"(review with purge_zero_class.py, see #31): {sorted(skipped)[:20]}"
               f"{' ...' if len(skipped) > 20 else ''}", flush=True)
 
     # Sort each bucket largest first so big ones get placed earliest

--- a/scripts/plan_distribution.py
+++ b/scripts/plan_distribution.py
@@ -282,7 +282,10 @@ def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]
     pinned = [r for r in records if (r.get("id") or "").lower() in PINNED_GIANTS]
     records = [r for r in records if (r.get("id") or "").lower() not in PINNED_GIANTS]
 
-    # Group records by bucket, drop entries with no classes data
+    # Group records by bucket. Ontologies with 0 / no class data are NOT allocated:
+    # a 0-owl:Class entry is a SKOS/DCAT non-ontology, not something to reason over
+    # (see #31; find/purge them with scripts/purge_zero_class.py). Surface the set
+    # instead of dropping it silently.
     by_bucket: dict[str, list[dict]] = defaultdict(list)
     skipped = []
     for r in records:
@@ -290,6 +293,10 @@ def plan(records: list[dict], preserve_memory: bool, current_mem: dict[int, int]
             skipped.append(r["id"])
             continue
         by_bucket[class_bucket(r["classes"])].append(r)
+    if skipped:
+        print(f"  plan: {len(skipped)} ontologies have 0/no classes — not allocated "
+              f"(0-class candidates for purge, see #31): {sorted(skipped)[:20]}"
+              f"{' ...' if len(skipped) > 20 else ''}", flush=True)
 
     # Sort each bucket largest first so big ones get placed earliest
     for b in by_bucket.values():

--- a/scripts/purge_zero_class.py
+++ b/scripts/purge_zero_class.py
@@ -1,80 +1,92 @@
 #!/usr/bin/env python3
-"""Find (and optionally purge) registry entries that are not real OWL class
-ontologies — i.e. 0 owl:Class. These are typically SKOS concept schemes or DCAT
-catalogues (e.g. ncod, shedding-hub) that ELK has nothing to classify and the UI
-can't browse as a hierarchy.
+"""Find (and optionally purge) registry entries that have no content AberOWL can
+serve. AberOWL reasons over owl:Class hierarchies, so an entry with **0 owl:Class**
+isn't browsable as a class hierarchy — but 0 classes does NOT mean empty: SKOS
+concept schemes / DCAT catalogues have an ABox (individuals / skos:Concepts).
 
-Detection is **file-based** (counts class declarations in the on-disk .owl),
-not the registry's cached class_count — so it distinguishes a genuine
-non-ontology from one that merely failed to load and happens to report 0.
-Counts both `owl:Class` (RDF/XML, Turtle) and `[Term]` (OBO format); SKOS
-`skos:Concept` is intentionally NOT counted.
+So this tool counts BOTH the TBox (owl:Class + OBO [Term]) and the ABox
+(owl:NamedIndividual + skos:Concept) from the on-disk .owl (file-based, robust
+vs a load-failure that merely reports 0), and splits 0-class entries into:
 
-Runs on the server that has the ontology files + the Redis container (onto).
-Dry-run by default; --apply HDELs the flagged entries from registered_servers.
+  - EMPTY      : 0 classes AND 0 ABox            -> safe to purge
+  - ABOX-ONLY  : 0 classes but has individuals    -> NOT purged without --include-abox-only
+                 (review: may be a SKOS/data ontology worth keeping or handling specially)
+
+Dry-run by default. Runs on the host with the files + Redis container (onto).
 
     python3 scripts/purge_zero_class.py --sudo --redis-container deploy-redis-1
     python3 scripts/purge_zero_class.py --sudo --redis-container deploy-redis-1 --apply
+    python3 scripts/purge_zero_class.py --sudo --apply --include-abox-only   # also purge SKOS/data
 """
 import argparse, subprocess, sys
 
 
 def sh(args, cmd):
-    pre = (["sudo", "-n"] if args.sudo else [])
-    return subprocess.run(pre + cmd, capture_output=True, text=True).stdout
+    return subprocess.run((["sudo", "-n"] if args.sudo else []) + cmd,
+                          capture_output=True, text=True).stdout
 
 
-def redis(args, *redis_args):
-    return sh(args, ["docker", "exec", args.redis_container, "redis-cli"] + list(redis_args))
+def redis(args, *a):
+    return sh(args, ["docker", "exec", args.redis_container, "redis-cli"] + list(a))
 
 
-def class_count(args, path):
-    """Lines declaring a class (owl:Class or OBO [Term]); -1 if file missing."""
+def counts(args, path):
+    """(tbox, abox) line counts, or (None, None) if the file is missing.
+    tbox = owl:Class + OBO [Term]; abox = owl:NamedIndividual + skos:Concept."""
     out = sh(args, ["sh", "-c",
-                    f"if [ -f '{path}' ]; then grep -cE 'owl:Class|\\[Term\\]' '{path}'; "
-                    f"else echo -1; fi"]).strip()
+                    f"if [ -f '{path}' ]; then "
+                    f"grep -cE 'owl:Class|\\[Term\\]' '{path}'; "
+                    f"grep -cE 'owl:NamedIndividual|skos:Concept' '{path}'; "
+                    f"else echo MISSING; fi"]).split()
+    if out == ["MISSING"] or len(out) < 2:
+        return None, None
     try:
-        return int(out)
+        return int(out[0]), int(out[1])
     except ValueError:
-        return -1
+        return None, None
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--sudo", action="store_true", help="prefix docker/grep with sudo -n")
+    ap.add_argument("--sudo", action="store_true")
     ap.add_argument("--redis-container", default="deploy-redis-1")
     ap.add_argument("--ontologies-dir", default="/data/aberowl/ontologies")
-    ap.add_argument("--apply", action="store_true",
-                    help="HDEL the flagged 0-class entries (default: dry-run, list only)")
+    ap.add_argument("--apply", action="store_true", help="HDEL flagged entries (default: dry-run)")
+    ap.add_argument("--include-abox-only", action="store_true",
+                    help="also purge 0-class entries that DO have an ABox (SKOS/data). "
+                         "Off by default — those are surfaced for review, not auto-removed.")
     args = ap.parse_args()
 
     keys = [k.strip() for k in redis(args, "HKEYS", "registered_servers").splitlines() if k.strip()]
-    print(f"Scanning {len(keys)} registered ontologies (file-based owl:Class count)...")
-    zero, missing = [], []
+    print(f"Scanning {len(keys)} registered ontologies (TBox + ABox, file-based)...")
+    empty, abox_only, missing = [], [], []
     for k in sorted(keys):
-        path = f"{args.ontologies_dir}/{k}/{k}.owl"
-        c = class_count(args, path)
-        if c < 0:
+        tbox, abox = counts(args, f"{args.ontologies_dir}/{k}/{k}.owl")
+        if tbox is None:
             missing.append(k)
-        elif c == 0:
-            zero.append(k)
+        elif tbox == 0 and abox == 0:
+            empty.append(k)
+        elif tbox == 0:
+            abox_only.append((k, abox))
 
-    print(f"\n0-class (non-ontology) candidates: {len(zero)}")
-    for k in zero:
+    print(f"\nEMPTY (0 class, 0 ABox) — safe to purge: {len(empty)}")
+    for k in empty:
         print(f"  {k}")
+    print(f"\nABOX-ONLY (0 class, has individuals — REVIEW, not auto-purged): {len(abox_only)}")
+    for k, n in abox_only:
+        print(f"  {k}  (ABox: {n})")
     if missing:
-        print(f"\nFile missing — skipped (NOT purged), may need re-download: {len(missing)}")
-        for k in missing:
-            print(f"  {k}")
+        print(f"\nFILE MISSING — skipped (not purged): {len(missing)}: {missing}")
 
+    to_purge = list(empty) + ([k for k, _ in abox_only] if args.include_abox_only else [])
     if not args.apply:
-        print(f"\nDRY-RUN. Re-run with --apply to HDEL the {len(zero)} flagged entries.")
+        print(f"\nDRY-RUN. --apply would purge {len(to_purge)} entries"
+              f"{' (incl. ABox-only)' if args.include_abox_only else ' (EMPTY only; add --include-abox-only for SKOS/data)'}.")
         return 0
-
-    for k in zero:
+    for k in to_purge:
         redis(args, "HDEL", "registered_servers", k)
         print(f"  purged {k}")
-    print(f"\nPurged {len(zero)} entries from registered_servers.")
+    print(f"\nPurged {len(to_purge)} entries.")
     return 0
 
 

--- a/scripts/purge_zero_class.py
+++ b/scripts/purge_zero_class.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Find (and optionally purge) registry entries that are not real OWL class
+ontologies — i.e. 0 owl:Class. These are typically SKOS concept schemes or DCAT
+catalogues (e.g. ncod, shedding-hub) that ELK has nothing to classify and the UI
+can't browse as a hierarchy.
+
+Detection is **file-based** (counts class declarations in the on-disk .owl),
+not the registry's cached class_count — so it distinguishes a genuine
+non-ontology from one that merely failed to load and happens to report 0.
+Counts both `owl:Class` (RDF/XML, Turtle) and `[Term]` (OBO format); SKOS
+`skos:Concept` is intentionally NOT counted.
+
+Runs on the server that has the ontology files + the Redis container (onto).
+Dry-run by default; --apply HDELs the flagged entries from registered_servers.
+
+    python3 scripts/purge_zero_class.py --sudo --redis-container deploy-redis-1
+    python3 scripts/purge_zero_class.py --sudo --redis-container deploy-redis-1 --apply
+"""
+import argparse, subprocess, sys
+
+
+def sh(args, cmd):
+    pre = (["sudo", "-n"] if args.sudo else [])
+    return subprocess.run(pre + cmd, capture_output=True, text=True).stdout
+
+
+def redis(args, *redis_args):
+    return sh(args, ["docker", "exec", args.redis_container, "redis-cli"] + list(redis_args))
+
+
+def class_count(args, path):
+    """Lines declaring a class (owl:Class or OBO [Term]); -1 if file missing."""
+    out = sh(args, ["sh", "-c",
+                    f"if [ -f '{path}' ]; then grep -cE 'owl:Class|\\[Term\\]' '{path}'; "
+                    f"else echo -1; fi"]).strip()
+    try:
+        return int(out)
+    except ValueError:
+        return -1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sudo", action="store_true", help="prefix docker/grep with sudo -n")
+    ap.add_argument("--redis-container", default="deploy-redis-1")
+    ap.add_argument("--ontologies-dir", default="/data/aberowl/ontologies")
+    ap.add_argument("--apply", action="store_true",
+                    help="HDEL the flagged 0-class entries (default: dry-run, list only)")
+    args = ap.parse_args()
+
+    keys = [k.strip() for k in redis(args, "HKEYS", "registered_servers").splitlines() if k.strip()]
+    print(f"Scanning {len(keys)} registered ontologies (file-based owl:Class count)...")
+    zero, missing = [], []
+    for k in sorted(keys):
+        path = f"{args.ontologies_dir}/{k}/{k}.owl"
+        c = class_count(args, path)
+        if c < 0:
+            missing.append(k)
+        elif c == 0:
+            zero.append(k)
+
+    print(f"\n0-class (non-ontology) candidates: {len(zero)}")
+    for k in zero:
+        print(f"  {k}")
+    if missing:
+        print(f"\nFile missing — skipped (NOT purged), may need re-download: {len(missing)}")
+        for k in missing:
+            print(f"  {k}")
+
+    if not args.apply:
+        print(f"\nDRY-RUN. Re-run with --apply to HDEL the {len(zero)} flagged entries.")
+        return 0
+
+    for k in zero:
+        redis(args, "HDEL", "registered_servers", k)
+        print(f"  purged {k}")
+    print(f"\nPurged {len(zero)} entries from registered_servers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/purge_zero_class.py
+++ b/scripts/purge_zero_class.py
@@ -1,24 +1,30 @@
 #!/usr/bin/env python3
-"""Find (and optionally purge) registry entries that have no content AberOWL can
-serve. AberOWL reasons over owl:Class hierarchies, so an entry with **0 owl:Class**
-isn't browsable as a class hierarchy — but 0 classes does NOT mean empty: SKOS
-concept schemes / DCAT catalogues have an ABox (individuals / skos:Concepts).
+"""Find (and optionally purge) registry entries that AberOWL can't serve as a
+class hierarchy: **0 owl:Class per the reasoner**.
 
-So this tool counts BOTH the TBox (owl:Class + OBO [Term]) and the ABox
-(owl:NamedIndividual + skos:Concept) from the on-disk .owl (file-based, robust
-vs a load-failure that merely reports 0), and splits 0-class entries into:
+Detection uses the registry's reasoner-computed counts (`class_count`,
+`individual_count`) — NOT text greps. Class declarations take many syntactic
+forms (`owl:Class`, the full `owl#Class` URI, OWL/XML `<Class>`, default
+namespaces) that greps miss, so a grep-based scan falsely flags real ontologies
+(observed: acvd_ontology has 1719 classes but greps found 0). The reasoner count
+in the registry (populated by the central's getStatistics refresh) is reliable.
 
-  - EMPTY      : 0 classes AND 0 ABox            -> safe to purge
-  - ABOX-ONLY  : 0 classes but has individuals    -> NOT purged without --include-abox-only
-                 (review: may be a SKOS/data ontology worth keeping or handling specially)
+0 classes != empty. SKOS schemes / DCAT catalogues have an ABox, so candidates
+are split:
+  - EMPTY     : class_count == 0 AND individual_count == 0  -> safe to purge
+  - ABOX-ONLY : class_count == 0 AND individual_count  > 0  -> review only
+                (NOT purged unless --include-abox-only)
 
-Dry-run by default. Runs on the host with the files + Redis container (onto).
+Caveat: registry counts come from the last successful getStatistics refresh and
+can be STALE for a just-(re)loaded ontology (e.g. one loaded since the last
+refresh, or whose getStatistics is failing). Treat the dry-run as a candidate
+list to VERIFY, not a blind purge list. Offline entries are reported separately
+since their 0 may be a load failure, not a real 0-class.
 
     python3 scripts/purge_zero_class.py --sudo --redis-container deploy-redis-1
     python3 scripts/purge_zero_class.py --sudo --redis-container deploy-redis-1 --apply
-    python3 scripts/purge_zero_class.py --sudo --apply --include-abox-only   # also purge SKOS/data
 """
-import argparse, subprocess, sys
+import argparse, json, subprocess, sys
 
 
 def sh(args, cmd):
@@ -30,62 +36,63 @@ def redis(args, *a):
     return sh(args, ["docker", "exec", args.redis_container, "redis-cli"] + list(a))
 
 
-def counts(args, path):
-    """(tbox, abox) line counts, or (None, None) if the file is missing.
-    tbox = owl:Class + OBO [Term]; abox = owl:NamedIndividual + skos:Concept."""
-    out = sh(args, ["sh", "-c",
-                    f"if [ -f '{path}' ]; then "
-                    f"grep -cE 'owl:Class|\\[Term\\]' '{path}'; "
-                    f"grep -cE 'owl:NamedIndividual|skos:Concept' '{path}'; "
-                    f"else echo MISSING; fi"]).split()
-    if out == ["MISSING"] or len(out) < 2:
-        return None, None
-    try:
-        return int(out[0]), int(out[1])
-    except ValueError:
-        return None, None
-
-
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--sudo", action="store_true")
     ap.add_argument("--redis-container", default="deploy-redis-1")
-    ap.add_argument("--ontologies-dir", default="/data/aberowl/ontologies")
     ap.add_argument("--apply", action="store_true", help="HDEL flagged entries (default: dry-run)")
     ap.add_argument("--include-abox-only", action="store_true",
-                    help="also purge 0-class entries that DO have an ABox (SKOS/data). "
-                         "Off by default — those are surfaced for review, not auto-removed.")
+                    help="also purge 0-class entries that have an ABox (SKOS/data). Off by default.")
+    ap.add_argument("--include-offline", action="store_true",
+                    help="also consider offline entries (their 0 may be a load failure — risky).")
     args = ap.parse_args()
 
-    keys = [k.strip() for k in redis(args, "HKEYS", "registered_servers").splitlines() if k.strip()]
-    print(f"Scanning {len(keys)} registered ontologies (TBox + ABox, file-based)...")
-    empty, abox_only, missing = [], [], []
-    for k in sorted(keys):
-        tbox, abox = counts(args, f"{args.ontologies_dir}/{k}/{k}.owl")
-        if tbox is None:
-            missing.append(k)
-        elif tbox == 0 and abox == 0:
-            empty.append(k)
-        elif tbox == 0:
-            abox_only.append((k, abox))
+    rows = []
+    for l in redis(args, "HVALS", "registered_servers").splitlines():
+        l = l.strip()
+        if not l:
+            continue
+        try:
+            rows.append(json.loads(l))
+        except json.JSONDecodeError:
+            pass
 
-    print(f"\nEMPTY (0 class, 0 ABox) — safe to purge: {len(empty)}")
-    for k in empty:
-        print(f"  {k}")
-    print(f"\nABOX-ONLY (0 class, has individuals — REVIEW, not auto-purged): {len(abox_only)}")
-    for k, n in abox_only:
-        print(f"  {k}  (ABox: {n})")
-    if missing:
-        print(f"\nFILE MISSING — skipped (not purged): {len(missing)}: {missing}")
+    empty, abox_only, offline_zero = [], [], []
+    for d in rows:
+        o = d.get("ontology")
+        if (d.get("class_count") or 0) != 0:
+            continue
+        cls0_ind = d.get("individual_count") or 0
+        if d.get("status") != "online":
+            offline_zero.append((o, cls0_ind))
+        elif cls0_ind == 0:
+            empty.append(o)
+        else:
+            abox_only.append((o, cls0_ind))
 
-    to_purge = list(empty) + ([k for k, _ in abox_only] if args.include_abox_only else [])
+    print(f"Scanned {len(rows)} registry entries (reasoner class_count).\n")
+    print(f"EMPTY (online, 0 class, 0 individual) — safe to purge: {len(empty)}")
+    for o in sorted(empty):
+        print(f"  {o}")
+    print(f"\nABOX-ONLY (online, 0 class, has individuals) — REVIEW, not auto-purged: {len(abox_only)}")
+    for o, n in sorted(abox_only):
+        print(f"  {o}  (individuals: {n})")
+    print(f"\nOFFLINE + 0 class (could be a load failure / stale — NOT purged unless --include-offline): {len(offline_zero)}")
+    for o, n in sorted(offline_zero):
+        print(f"  {o}  (individuals: {n})")
+    print("\nNOTE: registry counts can be stale for recently-(re)loaded ontologies — VERIFY before --apply.")
+
+    to_purge = list(empty)
+    if args.include_abox_only:
+        to_purge += [o for o, _ in abox_only]
+    if args.include_offline:
+        to_purge += [o for o, _ in offline_zero]
     if not args.apply:
-        print(f"\nDRY-RUN. --apply would purge {len(to_purge)} entries"
-              f"{' (incl. ABox-only)' if args.include_abox_only else ' (EMPTY only; add --include-abox-only for SKOS/data)'}.")
+        print(f"\nDRY-RUN. --apply would purge {len(to_purge)} entries.")
         return 0
-    for k in to_purge:
-        redis(args, "HDEL", "registered_servers", k)
-        print(f"  purged {k}")
+    for o in to_purge:
+        redis(args, "HDEL", "registered_servers", o)
+        print(f"  purged {o}")
     print(f"\nPurged {len(to_purge)} entries.")
     return 0
 


### PR DESCRIPTION
Implements #31 with a **registry/reasoner-based** detector (not text greps — those miss `owl#Class`/OWL-XML/default-ns forms and falsely flagged 166 real ontologies, e.g. acvd_ontology with 1719 classes).

`scripts/purge_zero_class.py` uses the registry's reasoner-computed `class_count` + `individual_count`:
- **EMPTY** (online, 0 class, 0 individual) → safe to purge
- **ABOX-ONLY** (online, 0 class, has individuals — SKOS/DCAT) → surfaced for review, not purged without `--include-abox-only`
- **offline + 0 class** → reported separately (0 may be a load failure)

Dry-run default; warns that counts can be stale (verify before `--apply`). `plan_distribution.py` surfaces its existing 0-class skip. Optional intake-time rejection left as a follow-up.

Closes #31