### PR TITLE
fix(worker): reconstruct root classes when getSubClasses(owl:Thing) is empty

### DIFF
--- a/aberowlapi/src/RequestManager.groovy
+++ b/aberowlapi/src/RequestManager.groovy
@@ -779,6 +779,33 @@ public class RequestManager {
             )
             resultSet.remove(df.getOWLNothing())
             resultSet.remove(df.getOWLThing())
+
+            // Fallback: some reasoner/ontology combinations do not enumerate the
+            // top-level classes via getSubClasses(owl:Thing, direct). In
+            // particular the StructuralReasoner (which we fall back to for
+            // incoherent or non-EL ontologies, e.g. ACGT, ALCROIQD) reports each
+            // root's superclass as owl:Thing yet returns nothing for
+            // getSubClasses(owl:Thing, direct) — leaving the hierarchy with "No
+            // root classes". Reconstruct the roots directly: a named, satisfiable
+            // class is a display root when its only direct superclass is owl:Thing.
+            if (resultSet.isEmpty()) {
+                def reasoner = qEngine.getoReasoner()
+                def topNode = reasoner.getTopClassNode()
+                def bottomNode = reasoner.getBottomClassNode()
+                def roots = new HashSet<OWLClass>()
+                for (OWLClass c : ontologies.get(ontId).getClassesInSignature(true)) {
+                    if (c.isOWLThing() || c.isOWLNothing()) continue
+                    if (topNode.contains(c) || bottomNode.contains(c)) continue  // skip Thing-equiv / unsatisfiable
+                    def directSupers = reasoner.getSuperClasses(c, true).getFlattened()
+                    if (directSupers.every { it.isOWLThing() || topNode.contains(it) }) {
+                        roots.add(c)
+                    }
+                    if (roots.size() >= MAX_REASONER_RESULTS) break
+                }
+                resultSet = roots
+                println "Root pre-compute for ${ontId}: getSubClasses(owl:Thing) was empty; reconstructed ${roots.size()} roots from the superclass graph"
+            }
+
             def classes = classes2info(ontId, resultSet, false, sfp)
             def sorted = classes.sort { x, y -> x["label"].compareTo(y["label"]) }
             rootClassCache.put(ontId, sorted)


### PR DESCRIPTION
## Summary
Fixes ontologies that render **"No root classes"** in the class hierarchy — e.g. the **ACGT Master Ontology** (`acgt-mo`) on https://beta.aber-owl.net.

## Root cause
`acgt-mo` is ALCROIQD (full OWL DL) but configured with **ELK** (EL-only). It is incoherent under ELK, so `RequestManager` falls back to the OWLAPI **StructuralReasoner**. That reasoner returns **empty** for `getSubClasses(owl:Thing, direct)` even though the classes exist — verified on live:

```
getSuperClasses(AdjuvantTherapy, direct) => {owl:Thing}   # it IS a root
getSubClasses(owl:Thing, direct)         => []            # but not enumerated
```

Roots are precomputed from that empty call into `rootClassCache` (also used by the runQuery fast-path), so the tree shows nothing.

## Fix
In `precomputeRootClasses`, when `getSubClasses(owl:Thing, direct)` is empty, reconstruct roots by scanning the signature for named, satisfiable classes whose only direct superclass is `owl:Thing`. Reasoner-agnostic; healthy EL ontologies (GO, etc.) never enter the fallback.

## Testing
- Diagnosis confirmed against the live worker API (super/subclass probes above).
- Healthy ontologies keep the fast path (GO returns its 3 roots unchanged).
- Requires reclassifying `acgt-mo` (worker restart) to take effect on the live site.

Closes #39