### PR TITLE
fix(central): demote description-like titles so real ontology names surface

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -505,10 +505,42 @@ async def _reapply_registry_fallbacks_to_all():
         logger.info(f"Re-applied registry fallbacks; updated {updated} server entries")
 
 
+def _looks_like_description(text: str) -> bool:
+    """Heuristic: is this 'title' actually a description/abstract?
+
+    Some ontologies put a whole paragraph in dc:title (e.g. birthonto's 1480-char
+    blurb), so the frontend shows prose where a name belongs. We treat a value as
+    description-like when it spans multiple lines, or is long *and* reads as a
+    sentence (leading article, an internal sentence break, or a long "X: …"
+    expansion). Tuned against the live registry so legitimate long acronym
+    expansions ("Promoting Health Aging through …", BRIDG, ICD-10-CM) are kept.
+    """
+    t = (text or "").strip()
+    if not t:
+        return False
+    if "\n" in t:
+        return True
+    if len(t) > 180:
+        return True
+    if len(t) > 85:
+        low = t.lower()
+        if low.startswith(("a ", "an ", "the ")) or ". " in t or (": " in t and len(t) > 110):
+            return True
+    return False
+
+
 def _apply_registry_fallbacks(server: Dict[str, Any]):
     """Backfill empty metadata fields on a registry entry from the OBO Foundry /
     BioPortal registry cache. OWL-file-derived values always win; this only
     fills blanks."""
+    # Demote a description-like title (paragraph stuffed into dc:title) into the
+    # description field so the registry/BioPortal name below can take its place.
+    title = (server.get("title") or "").strip()
+    if title and _looks_like_description(title):
+        if not (server.get("description") or "").strip():
+            server["description"] = title
+        server["title"] = ""
+
     ontology = (server.get("ontology") or "").lower()
     meta = _obo_metadata.get(ontology)
     if not meta:


### PR DESCRIPTION
## Summary
Stops description paragraphs that are stuffed into `dc:title` from showing up as ontology names in the list — e.g. `birthonto`, whose "title" is a 1480-character abstract.

## Fix
`_apply_registry_fallbacks` (the per-entry metadata backfill, run on every worker poll) now demotes a description-like title into the `description` field and clears `title`, so the OBO Foundry / BioPortal registry name can refill it on the same pass.

`_looks_like_description` flags a value as prose when it is multi-line, very long, or long *and* sentence-shaped (leading article, internal sentence break, or a long `X: …` expansion).

## Validation against the live registry (861 ontologies)
- **Demotes 7** genuine abstracts: `birthonto`, `bmt`, `edem-connectonto`, `nifsubcell`, `ontosim`, `brain-cof`, `ontosinasc`.
- **Keeps all 15** legitimate long acronym-expansion names (BRIDG, ICD-10-CM, "Promoting Health Aging through…", etc.).

Idempotent across polling cycles. Takes effect within one 60s metadata cycle after the central server is redeployed.

Closes #40