### PR TITLE
fix(frontend): show acronym instead of em-dash for nameless ontologies

### DIFF
--- a/central_server/frontend/src/pages/Home.tsx
+++ b/central_server/frontend/src/pages/Home.tsx
@@ -135,7 +135,9 @@ export default function Home() {
                       {o.id.toUpperCase()}
                     </Link>
                   </td>
-                  <td className="px-4 py-2.5 text-gray-700">{o.title || <span className="text-gray-400 italic">—</span>}</td>
+                  <td className="px-4 py-2.5 text-gray-700">
+                    {o.title || <span className="text-gray-400" title="No descriptive name available — showing the ontology acronym">{o.id.toUpperCase()}</span>}
+                  </td>
                   <td className="px-4 py-2.5 text-center">
                     <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
                       o.status === 'online'


### PR DESCRIPTION
## Summary
On the ontology list, **475 of 861** ontologies have no registry title and rendered a blank `—` in the Name column.

## Fix
`Home.tsx` now falls back to the uppercased ontology acronym (muted, with a tooltip explaining it) instead of `—` when no title is available. This matches `OntologyPage`, which already falls back to the ID.

## Notes
- Type-checks clean (`tsc --noEmit`).
- Complementary follow-up (separate from this display fix): re-run `deploy/fetch_metadata.py --force` with a valid BioPortal key to populate real names at the source — the current key is expired.

Closes #41