### PR TITLE
feat(mcp): add lookup_iri tool to resolve labels/CURIEs/IRIs to canonical IRIs

### DIFF
--- a/central_server/mcp_ontology_server.py
+++ b/central_server/mcp_ontology_server.py
@@ -9,6 +9,7 @@ and remote access.
 Tools:
   - list_ontologies: List all registered ontologies with status
   - search_classes: Search for classes by label/synonym across ontologies
+  - lookup_iri: Resolve a label / CURIE / candidate IRI to its canonical ontology IRI
   - run_dl_query: Execute a Description Logic query in Manchester OWL Syntax
   - get_class_info: Get detailed annotations for a specific class
   - get_ontology_info: Get metadata about a specific ontology
@@ -24,6 +25,7 @@ Usage:
 
 import json
 import os
+import re
 import sys
 from typing import Any
 
@@ -119,6 +121,283 @@ async def search_classes(query: str, ontology: str | None = None, size: int = 50
         if defn:
             lines.append(f"    Def: {defn[:150]}")
     return "\n".join(lines)
+
+
+# --- IRI resolution helpers (used by lookup_iri) -------------------------------
+#
+# Using the wrong IRI is a dominant agent failure mode: a guessed-but-wrong IRI
+# silently returns zero results from the reasoner/SPARQL tools with no error.
+# These helpers resolve a label, CURIE/OBO id, or candidate IRI to the canonical
+# IRI. They prefer the fast central ES index (exact oboid/label) and fall back to
+# the reasoner (which works even when the class index is unpopulated), so the
+# tool is robust to ES outages.
+
+_IRI_RE = re.compile(r"^https?://", re.I)
+# CURIE / OBO short form, e.g. GO:0006915 or GO_0006915 (no spaces).
+_CURIE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*[:_][A-Za-z0-9][A-Za-z0-9_]*$")
+# Local fragment that looks like an OBO id, e.g. GO_0006915 -> ("GO", "0006915").
+_FRAG_RE = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_([A-Za-z0-9]+)$")
+
+
+def _strip_iri(s: str) -> str:
+    s = (s or "").strip()
+    if s.startswith("<") and s.endswith(">"):
+        s = s[1:-1].strip()
+    return s
+
+
+def _first(v: Any) -> str:
+    if isinstance(v, list):
+        return str(v[0]) if v else ""
+    return str(v) if v is not None else ""
+
+
+def _norm(s: str) -> str:
+    return (s or "").strip().lower()
+
+
+def _classify(term: str) -> str:
+    """Classify the input as 'iri', 'curie', or 'text' (label)."""
+    t = _strip_iri(term)
+    if _IRI_RE.match(t):
+        return "iri"
+    if " " not in t and _CURIE_RE.match(t):
+        return "curie"
+    return "text"
+
+
+def _iri_to_curie(iri: str) -> str | None:
+    frag = re.split(r"[#/]", iri.rstrip("#/"))[-1]
+    m = _FRAG_RE.match(frag)
+    return f"{m.group(1)}:{m.group(2)}" if m else None
+
+
+def _curie_parts(curie: str) -> tuple[str, str]:
+    m = re.match(r"^([A-Za-z][A-Za-z0-9]*)[:_](.+)$", curie)
+    return (m.group(1), m.group(2)) if m else (curie, "")
+
+
+def _quote_label(label: str) -> str:
+    """Single-quote a label for Manchester OWL Syntax."""
+    return "'" + label.replace("'", "\\'") + "'"
+
+
+def _record(iri: str, label: str = "", ontology: str = "", curie: str = "",
+            definition: str = "", match: str = "exact") -> dict:
+    iri = _strip_iri(iri)
+    return {
+        "iri": iri,
+        "label": label or curie or _iri_to_curie(iri) or iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1],
+        "ontology": ontology or "",
+        "curie": curie or _iri_to_curie(iri) or "",
+        "definition": definition or "",
+        "match": match,
+    }
+
+
+async def _es_records(term: str, ontology: str | None, size: int) -> list[dict]:
+    """Class hits from the central ES index (empty if the index is unpopulated)."""
+    params: dict[str, Any] = {"query": term, "size": str(size)}
+    if ontology:
+        params["ontologies"] = ontology
+    try:
+        data = await _api_get("/api/search_all", params)
+    except Exception:
+        return []
+    out = []
+    for r in (data.get("result", []) if isinstance(data, dict) else []):
+        iri = _strip_iri(r.get("class") or r.get("owlClass") or "")
+        if not iri:
+            continue
+        out.append(_record(iri, _first(r.get("label")), r.get("ontology", ""),
+                           _first(r.get("oboid")), _first(r.get("definition"))))
+    return out
+
+
+async def _dl_equivalent(query: str, ontology: str) -> list[dict]:
+    """Resolve via the reasoner: equivalent classes of a label/IRI query.
+
+    Always scoped to one ontology — an unscoped dlquery_all fans out to every
+    worker, which is both slow (tens of seconds) and noisy, so the reasoner
+    fallback is only used when an ontology is known.
+    """
+    params: dict[str, Any] = {
+        "query": query, "type": "equivalent", "labels": "true", "ontologies": ontology,
+    }
+    try:
+        data = await _api_get("/api/dlquery_all", params)
+    except Exception:
+        return []
+    out = []
+    for r in (data.get("result", []) if isinstance(data, dict) else []):
+        iri = _strip_iri(r.get("class") or r.get("owlClass") or "")
+        if iri:
+            out.append(_record(iri, _first(r.get("label")), r.get("ontology", ""),
+                               "", _first(r.get("definition")), match="reasoner"))
+    return out
+
+
+async def _validate_iri(iri: str, ontology: str) -> dict | None:
+    """Confirm an IRI exists in an ontology and fetch its label/definition."""
+    try:
+        data = await _api_get("/api/getClass", {"query": iri, "ontology": ontology})
+    except Exception:
+        return None
+    if not isinstance(data, dict) or data.get("error"):
+        return None
+    riri = _strip_iri(data.get("class") or iri)
+    return _record(riri, _first(data.get("label")), data.get("ontology") or ontology,
+                   _first(data.get("oboid")), _first(data.get("definition")))
+
+
+def _dedup(records: list[dict], limit: int) -> list[dict]:
+    seen, out = set(), []
+    for r in records:
+        if r["iri"] and r["iri"] not in seen:
+            seen.add(r["iri"])
+            out.append(r)
+        if len(out) >= limit:
+            break
+    return out
+
+
+async def _resolve(term: str, ontology: str | None, limit: int) -> tuple[str, list[dict]]:
+    kind = _classify(term)
+    t = _strip_iri(term)
+
+    if kind == "iri":
+        # Validate against the most likely ontology: the caller's hint, then the
+        # one implied by an OBO-style IRI (purl.obolibrary.org/obo/GO_… -> go).
+        guesses, seen_g = [], set()
+        if ontology:
+            guesses.append(ontology)
+        curie = _iri_to_curie(t)
+        if curie:
+            guesses.append(curie.split(":")[0].lower())
+        for g in guesses:
+            if not g or g in seen_g:
+                continue
+            seen_g.add(g)
+            rec = await _validate_iri(t, g)
+            if rec:
+                return kind, [rec]
+        # Scoped reasoner backstop only when an ontology was given explicitly.
+        if ontology:
+            hits = [r for r in await _dl_equivalent(f"<{t}>", ontology) if r["iri"] == t]
+            return kind, _dedup(hits, limit)
+        return kind, []
+
+    if kind == "curie":
+        prefix, local = _curie_parts(t)
+        colon = f"{prefix}:{local}"
+        # 1) ES exact oboid match.
+        es = [r for r in await _es_records(colon, ontology, limit)
+              if _norm(r["curie"]) == _norm(colon)]
+        if es:
+            for r in es:
+                r["match"] = "curie"
+            return kind, _dedup(es, limit)
+        # 2) Construct the OBO PURL IRI and validate it against the ontology the
+        #    prefix implies (GO:… -> go) unless the caller scoped one explicitly.
+        cand = f"http://purl.obolibrary.org/obo/{prefix}_{local}"
+        rec = await _validate_iri(cand, ontology or prefix.lower())
+        if rec:
+            rec["match"] = "curie"
+            return kind, [rec]
+        return kind, []
+
+    # text / label: ES first (fast, cross-ontology); reasoner only when scoped,
+    # since an unscoped label query would fan out to every worker.
+    records = await _es_records(t, ontology, limit)
+    if not records and ontology:
+        records = await _dl_equivalent(_quote_label(t), ontology)
+    return kind, _dedup(records, limit)
+
+
+async def _suggest(term: str, ontology: str | None, limit: int = 5) -> list[dict]:
+    """Best-effort 'did you mean' suggestions for a failed lookup (needs ES)."""
+    t = _strip_iri(term)
+    frag = re.split(r"[#/]", t.rstrip("#/"))[-1] if _IRI_RE.match(t) else t
+    frag = re.sub(r"[_:]", " ", frag).strip()
+    return _dedup(await _es_records(frag, ontology, limit), limit) if frag else []
+
+
+def _fmt_record(rec: dict, idx: int | None = None) -> str:
+    head = f"{idx}. " if idx else "✓ "
+    lines = [f"{head}{rec['iri']}"]
+    pad = "   "
+    if rec.get("label"):
+        lines.append(f"{pad}label:    {rec['label']}")
+    if rec.get("curie"):
+        lines.append(f"{pad}CURIE:    {rec['curie']}")
+    if rec.get("ontology"):
+        lines.append(f"{pad}ontology: {rec['ontology']}")
+    if rec.get("definition"):
+        lines.append(f"{pad}def:      {rec['definition'][:160]}")
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    description=(
+        "Resolve a class name, CURIE/OBO id (e.g. GO:0006915), or a candidate "
+        "IRI to its canonical AberOWL ontology IRI. USE THIS to obtain or verify "
+        "an IRI before passing one to get_class_info, browse_hierarchy, "
+        "run_dl_query, or SPARQL — a guessed-but-wrong IRI silently returns zero "
+        "results with no error, which is a common failure.\n\n"
+        "Accepts:\n"
+        "  - a label, e.g. 'apoptosis' or 'apoptotic process'\n"
+        "  - a CURIE / OBO id, e.g. 'GO:0006915' or 'GO_0006915'\n"
+        "  - a full IRI to validate, e.g. 'http://purl.obolibrary.org/obo/GO_0006915'\n\n"
+        "Pass `ontology` (e.g. 'go', 'hp') to scope and disambiguate — recommended "
+        "and faster. Returns the canonical IRI, label, CURIE, and source ontology. "
+        "If the IRI/CURIE does not exist it says so and suggests close matches, so "
+        "you can correct course instead of querying a non-existent class."
+    ),
+)
+async def lookup_iri(term: str, ontology: str | None = None, limit: int = 10) -> str:
+    """
+    Args:
+        term: A class label, CURIE/OBO id, or candidate IRI to resolve/validate.
+        ontology: Optional ontology ID to scope/disambiguate (e.g. 'go', 'hp').
+        limit: Maximum number of matches to return (default 10).
+    """
+    term = (term or "").strip()
+    if not term:
+        return "Provide a class name, CURIE (e.g. GO:0006915), or IRI to look up."
+
+    kind, records = await _resolve(term, ontology, limit)
+
+    if records:
+        if len(records) == 1:
+            r = records[0]
+            return (
+                f'Resolved "{term}" ({kind}) -> 1 match:\n\n{_fmt_record(r)}\n\n'
+                f"Use this IRI verbatim: in run_dl_query wrap it as <{r['iri']}>; "
+                f"in get_class_info / browse_hierarchy pass class_iri=\"{r['iri']}\""
+                + (f" with ontology=\"{r['ontology']}\"" if r['ontology'] else "")
+                + f"; in SPARQL use <{r['iri']}>."
+            )
+        lines = [f'Resolved "{term}" ({kind}) -> {len(records)} matches'
+                 + ("" if ontology else " (pass `ontology` to narrow):") + "\n"]
+        for i, r in enumerate(records, 1):
+            lines.append(_fmt_record(r, idx=i))
+        return "\n".join(lines)
+
+    # Not found — offer suggestions.
+    kind_word = "an IRI" if kind == "iri" else f"a {kind}"
+    out = [f'✗ Could not resolve "{term}" as {kind_word}.']
+    if kind in ("iri", "curie"):
+        out.append("  It may not exist in AberOWL, or the ontology uses a different namespace.")
+    sugg = await _suggest(term, ontology, 5)
+    if sugg:
+        out.append("  Closest matches:")
+        for r in sugg:
+            tail = f"  ({r['label']} [{r['ontology']}])" if r.get("label") else ""
+            out.append(f"  - {r['iri']}{tail}")
+    else:
+        hint = "omit `ontology`" if ontology else "specify the `ontology`"
+        out.append(f'  No close matches. Try search_classes("{term}") or {hint}.')
+    return "\n".join(out)
 
 
 @mcp.tool(

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -52,8 +52,20 @@ class TestMCPOntologyServerSchemas:
             "rewrite_sparql",
             "list_sparql_examples",
             "query_sparql",
+            "lookup_iri",
         }
         assert tool_names == expected, f"Missing tools: {expected - tool_names}"
+
+    async def test_lookup_iri_schema(self):
+        from mcp_ontology_server import mcp
+        tools = await mcp.list_tools()
+        tool = next(t for t in tools if t.name == "lookup_iri")
+        schema = tool.inputSchema
+        assert "term" in schema["properties"]
+        assert "term" in schema["required"]
+        assert "ontology" in schema["properties"]
+        # ontology is optional — it must not be required
+        assert "ontology" not in schema.get("required", [])
 
     async def test_search_classes_schema(self):
         from mcp_ontology_server import mcp
@@ -172,6 +184,110 @@ class TestMCPOntologyServerCalls:
                 "get_class_info", {"class_iri": "bad", "ontology": "go"}
             )
         assert "Error: HTTP 404" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# lookup_iri — input classification helpers + resolution behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestLookupIRIHelpers:
+
+    def test_classify(self):
+        import mcp_ontology_server as srv
+        assert srv._classify("apoptosis") == "text"
+        assert srv._classify("apoptotic process") == "text"
+        assert srv._classify("GO:0006915") == "curie"
+        assert srv._classify("GO_0006915") == "curie"
+        assert srv._classify("http://purl.obolibrary.org/obo/GO_0006915") == "iri"
+        assert srv._classify("<http://purl.obolibrary.org/obo/HP_0001250>") == "iri"
+        assert srv._classify("Alzheimer's disease") == "text"
+
+    def test_iri_curie_conversions(self):
+        import mcp_ontology_server as srv
+        assert srv._iri_to_curie("http://purl.obolibrary.org/obo/GO_0006915") == "GO:0006915"
+        assert srv._iri_to_curie("http://example.org/onto#Plainname") is None
+        assert srv._curie_parts("GO:0006915") == ("GO", "0006915")
+        assert srv._curie_parts("GO_0006915") == ("GO", "0006915")
+
+
+@pytest.mark.unit
+class TestLookupIRICalls:
+
+    async def test_curie_constructs_and_validates_iri(self):
+        """A CURIE with no ES hit is resolved by constructing the OBO PURL and
+        validating it via getClass."""
+        import mcp_ontology_server as srv
+
+        async def fake_get(path, params=None):
+            params = params or {}
+            if path == "/api/search_all":
+                return {"result": []}  # ES unpopulated
+            if path == "/api/getClass":
+                assert params["query"] == "http://purl.obolibrary.org/obo/GO_0006915"
+                assert params["ontology"] == "go"  # inferred from the GO prefix
+                return {"class": params["query"], "label": "apoptotic process", "ontology": "go"}
+            return {"result": []}
+
+        with patch.object(srv, "_api_get", new=AsyncMock(side_effect=fake_get)):
+            result = await srv.mcp.call_tool("lookup_iri", {"term": "GO:0006915"})
+        text = _text(result)
+        assert "http://purl.obolibrary.org/obo/GO_0006915" in text
+        assert "apoptotic process" in text
+        assert "GO:0006915" in text
+
+    async def test_label_resolves_via_reasoner_when_scoped(self):
+        """When ES is empty, a scoped label resolves through the reasoner."""
+        import mcp_ontology_server as srv
+
+        async def fake_get(path, params=None):
+            params = params or {}
+            if path == "/api/search_all":
+                return {"result": []}
+            if path == "/api/dlquery_all":
+                assert params["ontologies"] == "go"
+                assert params["type"] == "equivalent"
+                return {"result": [{"class": "http://purl.obolibrary.org/obo/GO_0006915",
+                                    "label": "apoptotic process", "ontology": "go"}]}
+            return {"result": []}
+
+        with patch.object(srv, "_api_get", new=AsyncMock(side_effect=fake_get)):
+            result = await srv.mcp.call_tool("lookup_iri", {"term": "apoptosis", "ontology": "go"})
+        text = _text(result)
+        assert "http://purl.obolibrary.org/obo/GO_0006915" in text
+        assert "apoptotic process" in text
+
+    async def test_unscoped_label_does_not_scatter(self):
+        """An unscoped label with no ES hit must NOT call the reasoner (which
+        would fan out to every worker); it returns guidance instead."""
+        import mcp_ontology_server as srv
+        calls = []
+
+        async def fake_get(path, params=None):
+            calls.append(path)
+            return {"result": []}
+
+        with patch.object(srv, "_api_get", new=AsyncMock(side_effect=fake_get)):
+            result = await srv.mcp.call_tool("lookup_iri", {"term": "apoptosis"})
+        text = _text(result)
+        assert "Could not resolve" in text
+        assert "ontology" in text  # guidance to scope
+        assert "/api/dlquery_all" not in calls  # never scattered
+
+    async def test_missing_iri_reports_not_found(self):
+        import mcp_ontology_server as srv
+
+        async def fake_get(path, params=None):
+            if path == "/api/getClass":
+                return {"error": "HTTP 404: Class not found"}
+            return {"result": []}
+
+        with patch.object(srv, "_api_get", new=AsyncMock(side_effect=fake_get)):
+            result = await srv.mcp.call_tool(
+                "lookup_iri",
+                {"term": "http://purl.obolibrary.org/obo/GO_9999999", "ontology": "go"},
+            )
+        assert "Could not resolve" in _text(result)
 
     async def test_get_ontology_info_returns_json(self):
         import mcp_ontology_server as srv


### PR DESCRIPTION
## Summary
Adds an MCP tool **`lookup_iri(term, ontology?, limit?)`** that resolves a class **label**, **CURIE/OBO id**, or a **candidate IRI** to its canonical AberOWL ontology IRI. Using the wrong IRI is a dominant agent failure mode — a guessed-but-wrong IRI silently returns zero results from the reasoner/SPARQL tools with *no error* — and there was no tool whose job was to hand back the correct one.

## Behaviour
```
lookup_iri("apoptosis", ontology="go")
  -> http://purl.obolibrary.org/obo/GO_0006915  (apoptotic process, GO:0006915, go)
lookup_iri("GO:0006915")           # or GO_0006915
  -> resolves cross-ontology, infers ontology from the prefix
lookup_iri("http://purl.obolibrary.org/obo/GO_9999999", ontology="go")
  -> ✗ Could not resolve … (does not exist; suggests close matches)
```
Each success returns IRI + label + CURIE + ontology + definition, plus an explicit "use this IRI verbatim in run_dl_query/get_class_info/SPARQL" line.

## Design
- **ES-first, reasoner-fallback** — prefers the central class index (exact `oboid`/`label`), falls back to the reasoner (`dlquery_all` equivalent / `getClass`). Works even when the ES class index is unpopulated.
- **Reasoner path is scoped-only** — an unscoped `dlquery_all` fans out to every worker (tens of seconds + noisy: ~3,400 loose hits for `apoptosis`). Unscoped misses return fast guidance to specify an ontology instead.
- **CURIE resolution** normalises `_`/`:` and constructs+validates the OBO PURL via `getClass`.
- **Exception-safe** — every backend call degrades to empty/None rather than crashing the tool.

## Testing
- Verified **end-to-end against live beta** across labels, multi-word labels, colon/underscore CURIEs, cross-ontology CURIEs, IRI validation, and missing IRIs/labels — all correct, all fast (≈0.6–1.5s; the only slow case is the pre-existing `getClass` worker-fallback for a non-existent IRI).
- 8 new unit tests (classification helpers + mocked resolution, incl. an assertion that unscoped labels never scatter). Full suite: **30 passed**.

## Notes
- **Separate finding:** the central ES class index appears **empty on beta** — `/api/search_all` and `/api/queryNames` return nothing even for online ontologies with 50k+ classes, which also breaks the existing `search_classes` tool. Filed in #47; `lookup_iri` is built to work regardless, but the indexing pipeline is worth a look.
- The Docs/MCP page (#46) tool list should gain a `lookup_iri` row once both land; happy to do that as a quick follow-up.

Closes #47