### PR TITLE
fix(central): match dlquery_all ontology ids case-insensitively (OBO/legacy links)

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -801,8 +801,13 @@ async def dl_query_all(request: Request):
     online_servers = [s for s in all_servers if s.get("status") == "online"]
 
     if ontologies_to_query_str:
-        ontologies_to_query = [o.strip() for o in ontologies_to_query_str.split(',')]
-        online_servers = [s for s in online_servers if s.get("ontology") in ontologies_to_query]
+        # Match ontology ids case-insensitively. Registered ids are lowercase,
+        # but inbound ids are often upper/mixed case — notably the OBO Foundry
+        # browser links (http://aber-owl.net/ontology/DOID) and any legacy
+        # AberOWL 1 link. A case-sensitive match here selected zero workers, so
+        # the class hierarchy on those pages came back empty.
+        ontologies_to_query = {o.strip().lower() for o in ontologies_to_query_str.split(',')}
+        online_servers = [s for s in online_servers if s.get("ontology", "").lower() in ontologies_to_query]
 
     async def query_one_server(server, session):
         ontology_name = server.get("ontology")


### PR DESCRIPTION
## Summary
OBO Foundry links to AberOWL with an **uppercase** id — the DOID page links to `http://aber-owl.net/ontology/DOID` (and `GO`, `CL`, … likewise). When the new stack serves `aber-owl.net`, the SPA page loads and metadata resolves, but the **class hierarchy is empty**: `/api/dlquery_all` matched the requested ontology id against the registry case-sensitively, so `DOID` ≠ registered `doid`, no worker was selected, and the tree came back empty.

## Verified on beta
```
GET /api/dlquery_all  subclass owl:Thing  ontologies=DOID  -> 0 roots
GET /api/dlquery_all  subclass owl:Thing  ontologies=doid  -> 1 root
GET /ontology/DOID        -> 200 (SPA loads)
GET /api/getOntology?ontology=DOID -> doid / "Human Disease Ontology" / online
```
So only the DL query path was case-sensitive; `getOntology`/`getClass`/`search_all` already lowercase the id. The frontend's root + class-browse queries go through `dlquery_all`, hence the blank tree.

## Fix
Lowercase both sides when filtering workers by `ontologies` in the `dlquery_all` handler. The worker is still dispatched with its registered lowercase id, so nothing downstream changes. Also fixes mixed-case multi-ontology requests (`GO,DOID` previously matched nothing).

## Notes
- The OBO link is `http://` — ensure the production proxy redirects http→https when `aber-owl.net` cuts over.
- Pairs well with #42 (the ACGT empty-roots fix); both eliminate "loads but shows no classes" failure modes.

Closes #49