### PR TITLE
fix(deploy): correct beta deploy user to zhapacfp

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -504,6 +504,40 @@ What would destroy data:
 - `rm -rf /data/aberowl/ontologies` or `/var/lib/docker/volumes/deploy_*`.
 - Renaming the compose project (`-p` flag) — would create new volumes with the new prefix.
 
+### ALWAYS back up the current state before deploying (rollback safety)
+
+A normal `up --build -d` preserves volumes, but **always capture a rollback
+point first** so a bad deploy can be reverted. Run on `onto`, before syncing
+new code:
+
+```bash
+ssh onto
+cd /data/aberowl
+
+# 1. Record the currently-deployed code commit (to roll the code back).
+git rev-parse HEAD | tee backups/DEPLOYED_COMMIT_$(date +%Y%m%d_%H%M%S).txt
+
+# 2. Snapshot the data volumes (ES indices, Redis registry, config) to tarballs.
+ts=$(date +%Y%m%d_%H%M%S); mkdir -p backups/$ts
+for v in deploy_es_data deploy_redis_data deploy_central_config; do
+  docker run --rm -v "$v":/vol -v "$(pwd)/backups/$ts":/backup alpine \
+    tar czf "/backup/$v.tar.gz" -C /vol .
+done
+echo "Backup at /data/aberowl/backups/$ts"
+```
+
+(Volume names carry the `deploy_` compose-project prefix. `backups/` lives
+outside the rsync path, so deploys don't clobber it; prune old ones manually.)
+
+**Rollback:**
+- *Code:* `git checkout <recorded-commit>` (or re-sync the old tree) then
+  `docker compose -f deploy/docker-compose.central.yml --env-file deploy/.env up --build -d`.
+- *Data:* stop the stack, restore the tarball into the volume, restart, e.g.
+  `docker run --rm -v deploy_es_data:/vol -v "$(pwd)/backups/<ts>":/backup alpine sh -c 'rm -rf /vol/* && tar xzf /backup/deploy_es_data.tar.gz -C /vol'`.
+- *Schema/reindex changes:* reindex into a **new** versioned index and swap the
+  alias, keeping the old index — then rollback is just swapping the alias back,
+  with no data loss.
+
 For the MCP rollout specifically, the upgrade sequence is:
 
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,7 +67,7 @@ nothing else can. Public access is exclusively via the nginx route
 
 | Server | SSH | User | Notes |
 |--------|-----|------|-------|
-| onto (cbontsr01) | `ssh onto` | hohndor | Main deployment server. SSH key auth. |
+| onto (cbontsr01) | `ssh onto` | zhapacfp | Main deployment server. SSH key auth. |
 | frontend | See borg-infrastructure AGENTS.md | a-hohndor | Needs `sudo rootsh` for nginx changes. |
 | frontend1 | See borg-infrastructure AGENTS.md | a-hohndor | Same as frontend. |
 | borg-server | `ssh borg-server` | leechuck | Needs `sudo` for nginx. User `root` for direct access via `ssh root@borg-server`. |

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,7 +5,7 @@
 # at /data/aberowl/
 #
 # Prerequisites:
-#   - SSH access to "onto" as hohndor
+#   - SSH access to "onto" as zhapacfp
 #   - Docker and docker-compose installed on onto
 #   - /data/ directory exists with sufficient space
 #
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 REMOTE_HOST="onto"
-REMOTE_USER="hohndor"
+REMOTE_USER="zhapacfp"
 REMOTE_DIR="/data/aberowl"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
deploy.sh hardcoded `REMOTE_USER=hohndor`, but the beta server `onto` (`/data/aberowl`) is owned by and deployed as `zhapacfp` (verified: dir owner is zhapacfp; Fernando has deployed before). Corrects the script's `REMOTE_USER`, the prerequisites comment, and the server table in `deploy/README.md`. Leaves `frontend`/`frontend1` on `a-hohndor` (separate nginx infra).