### PR TITLE
fix(index): create class index centrally so synonyms.raw reaches production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Compute (where experiments run)
+
+Fernando codes on his laptop but runs experiments on a remote: **workstation** = `10.74.250.168`,
+**ibex** = `glogin.ibex.kaust.edu.sa` (KAUST Slurm cluster login node), **unimatrix** = `10.72.186.139`.
+When he names one, target that host; don't run heavy jobs on the laptop. See the root `CLAUDE.md` for
+details.
+
 ## Project Overview
 
 AberOWL 2 is a distributed ontology query system for biological/biomedical ontologies. A **central server** (Elasticsearch + Redis + FastAPI) owns shared infrastructure and the registry. **Worker containers** (one Groovy/OWLAPI process per container) each host **one or many ontologies** in-memory and serve DL reasoning queries. Workers register themselves with the central server; the central server dispatches queries to the correct worker by `ontologyId`.
@@ -102,6 +109,20 @@ End-to-end MCP testing:
 ```bash
 python agents/mcp_test_client.py --ontology http://localhost:8766
 ```
+
+## Deploying (beta)
+
+Beta runs on server `onto` (cbontsr01) under docker-compose project `deploy`;
+deploy with `deploy/deploy.sh` (full procedure + rollback in `deploy/README.md`).
+
+- **ALWAYS take a backup before deploying.** A deploy must never be the only
+  copy of the running state. Before any rebuild/restart: (1) record the deployed
+  commit, and (2) snapshot the data volumes (`deploy_es_data`, `deploy_redis_data`,
+  `deploy_central_config`) to `/data/aberowl/backups/<ts>/` — see the
+  "back up the current state before deploying" section in `deploy/README.md`.
+- **Verify changes are non-breaking before deploying.** Beta is a live service:
+  prefer additive/fallback changes, run the tests, and reason through whether the
+  change can alter existing behavior — not just the new path.
 
 ## Key Technical Details
 

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -426,6 +426,14 @@ async def execute_update_pipeline(
     new_es_index = await es_mgr.get_next_index_name(ontology_id)
     old_es_index = await es_mgr.get_current_index(ontology_id)
 
+    # Create the index centrally so it carries the single authoritative mapping
+    # (es_manager.CLASS_INDEX_SETTINGS, incl. the synonyms.raw sub-field that
+    # /api/resolve + find_iri need). The worker's IndexElastic.groovy only
+    # creates an index when one does not already exist, so pre-creating here
+    # makes the central mapping the global source of truth and the worker just
+    # writes documents into it.
+    await es_mgr.create_class_index(new_es_index)
+
     es_ok = True
     if server_url:
         index_task_id = await trigger_indexing(

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -351,7 +351,10 @@ async def execute_update_pipeline(
     Returns {"success": bool, "error": str|None, "new_md5": str|None}
     """
     source_url = registry_entry.get("source_url")
-    server_url = registry_entry.get("server_url")
+    # Registry entries store the worker URL under "url"; older code/paths used
+    # "server_url". Fall back so the indexing/hot-swap/alias steps (all guarded
+    # by `if server_url`) actually run instead of silently no-op'ing.
+    server_url = registry_entry.get("server_url") or registry_entry.get("url")
     secret_key = registry_entry.get("secret_key", "")
     stored_etag = registry_entry.get("source_etag")
     stored_lm = registry_entry.get("source_last_modified")

--- a/docker/scripts/IndexElastic.groovy
+++ b/docker/scripts/IndexElastic.groovy
@@ -175,7 +175,10 @@ def initIndex() {
 			"oboid": [
 			"type": "keyword", "normalizer": "aberowl_normalizer"],
 			"owlClass": ["type": "keyword"],
-			"synonyms": ["type": "text"],
+			// `.raw` keyword sub-field (lowercased) enables exact synonym
+			// matching for /api/resolve + the find_iri MCP tool; keep in sync
+			// with central_server/app/es_manager.py CLASS_INDEX_SETTINGS.
+			"synonyms": ["type": "text", "fields": ["raw": ["type": "keyword", "normalizer": "aberowl_normalizer"]]],
 		]
 		]
 	]


### PR DESCRIPTION
Follow-up to #51 / #52. The merged find_iri fix added `synonyms.raw` to central's `es_manager.CLASS_INDEX_SETTINGS`, but the **update pipeline never used it** — `updater.execute_update_pipeline` goes straight to the worker's `IndexElastic.groovy`, which *creates* the index with its own (drifted) mapping lacking `synonyms.raw`. So `find_iri`'s exact-synonym match silently fails on real deployments (it only worked locally because I rebuilt that index by hand).

**Fix (makes the central mapping the single global source of truth):**
- `updater.py`: `await es_mgr.create_class_index(new_es_index)` before triggering worker indexing. `IndexElastic` only creates an index when none exists, so pre-creating centrally means the worker just writes documents into the correctly-mapped index.
- `IndexElastic.groovy`: add `synonyms.raw` to its class mapping too — keeps direct-trigger paths (e.g. `reindex_local_test_worker.sh`) correct.

ES is a single central cluster with per-ontology indices; workers write into it but don't own the mapping. After merge + deploy, a fresh index (via intake/`trigger_update`) carries `synonyms.raw` and `find_iri` resolves exact synonyms.