### PR TITLE
feat(intake): auto source-sync/update off by default + on-demand + index fixes

### DIFF
--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -365,8 +365,9 @@ async def execute_update_pipeline(
     ont_dir = Path(ontologies_base_path) / ontology_id
     ont_dir.mkdir(parents=True, exist_ok=True)
     staging_path_host = str(ont_dir / f"{ontology_id}_staging.owl")
-    # Path as seen inside each container (mounted at /data/ontologies/{id}/ → /data/)
-    staging_path_container = f"/data/{ontology_id}_staging.owl"
+    # Path as seen inside the worker: the host ontologies dir is mounted at /data
+    # (`/data/aberowl/ontologies → /data`), so the file lives under /data/{id}/.
+    staging_path_container = f"/data/{ontology_id}/{ontology_id}_staging.owl"
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
 
@@ -405,12 +406,17 @@ async def execute_update_pipeline(
 
         new_md5 = dl_result["md5"]
 
-        # MD5 fallback: if no version headers were present, check MD5 now
+        # MD5 fallback: if no version headers were present, check MD5 now.
+        # Only treat "unchanged" as nothing-to-do when an ES index already
+        # exists — otherwise (e.g. a never-indexed ontology) we must still index
+        # the existing OWL even though the file hasn't changed.
         if version_info.get("need_md5") and new_md5 == stored_md5:
-            logger.info("%s: MD5 unchanged (%s), no update needed", ontology_id, new_md5)
-            await _touch_last_checked(redis_client, ontology_id)
-            _cleanup_staging(staging_path_host)
-            return {"success": True, "error": None, "new_md5": new_md5, "changed": False}
+            if await es_mgr.get_current_index(ontology_id):
+                logger.info("%s: MD5 unchanged (%s) and ES index present, no update needed", ontology_id, new_md5)
+                await _touch_last_checked(redis_client, ontology_id)
+                _cleanup_staging(staging_path_host)
+                return {"success": True, "error": None, "new_md5": new_md5, "changed": False}
+            logger.info("%s: MD5 unchanged but no ES index — indexing existing OWL", ontology_id)
 
     # Step 3: Validate via OntologyServer (if server is online)
     if server_url:

--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -57,6 +57,12 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "changeme")
 # Scheduling intervals
 SOURCE_SYNC_INTERVAL = int(os.getenv("SOURCE_SYNC_INTERVAL_SECONDS", "86400"))
 UPDATE_CHECK_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL_SECONDS", "86400"))
+# Automatic source-sync + update-check (which DOWNLOAD every ontology to check
+# for upstream changes) are OFF by default so a central restart never triggers a
+# corpus-wide download. Set ENABLE_AUTO_SYNC=true to run them on the daily
+# schedule; otherwise trigger them on demand via /admin/sync_sources and
+# /admin/check_updates.
+ENABLE_AUTO_SYNC = os.getenv("ENABLE_AUTO_SYNC", "false").lower() in ("1", "true", "yes")
 ONTOLOGIES_BASE_PATH = os.getenv("ONTOLOGIES_HOST_PATH", "/data/ontologies")
 ABEROWL_REPO_PATH = os.getenv("ABEROWL_REPO_PATH", "/opt/aberowl")
 
@@ -608,9 +614,18 @@ async def lifespan(app: FastAPI):
     # Start the periodic background task
     asyncio.create_task(periodic_metadata_fetch_task())
 
-    # Start intake scheduler tasks
-    asyncio.create_task(daily_source_sync_task())
-    asyncio.create_task(daily_update_check_task())
+    # Start intake scheduler tasks — ONLY when explicitly enabled, so a restart
+    # never kicks off a corpus-wide download. Otherwise these run on demand via
+    # the /admin/sync_sources and /admin/check_updates endpoints.
+    if ENABLE_AUTO_SYNC:
+        logger.info("ENABLE_AUTO_SYNC=true: starting daily source-sync + update-check tasks")
+        asyncio.create_task(daily_source_sync_task())
+        asyncio.create_task(daily_update_check_task())
+    else:
+        logger.info(
+            "ENABLE_AUTO_SYNC is off: automatic source-sync/update-check disabled. "
+            "Use POST /admin/sync_sources and /admin/check_updates to run them on demand."
+        )
 
     # Start MCP servers if enabled
     await start_mcp_servers()
@@ -2338,6 +2353,31 @@ async def admin_trigger_update(
 
     asyncio.create_task(_run())
     return {"status": "update_triggered", "ontology_id": ontology_id}
+
+
+@app.post("/admin/sync_sources")
+async def admin_sync_sources(
+    credentials: HTTPBasicCredentials = Depends(_require_admin),
+):
+    """On-demand source sync (refresh the ontology source list/metadata).
+
+    This is what `daily_source_sync_task` runs automatically only when
+    ENABLE_AUTO_SYNC=true; expose it here so it can be triggered deliberately.
+    """
+    asyncio.create_task(_sync_sources_once())
+    return {"status": "source_sync_triggered"}
+
+
+@app.post("/admin/check_updates")
+async def admin_check_updates(
+    credentials: HTTPBasicCredentials = Depends(_require_admin),
+):
+    """On-demand corpus update check (downloads each ontology to detect upstream
+    changes and re-index changed ones). Heavy — this is the whole-corpus
+    download pass, run it intentionally. Auto-runs only when ENABLE_AUTO_SYNC=true.
+    """
+    asyncio.create_task(_check_and_update_all())
+    return {"status": "update_check_triggered"}
 
 
 @app.post("/api/webhook/update/{ontology_id}")


### PR DESCRIPTION
Addresses the corpus-download-on-restart problem and two indexing bugs found while indexing GO/HP on beta.

**Why:** `daily_source_sync_task` + `daily_update_check_task` were started unconditionally at boot, and the update check downloads *every* registered ontology to MD5-compare. So every central restart triggered a whole-corpus download.

**Changes**
- **Auto-sync off by default:** gate both daily tasks behind `ENABLE_AUTO_SYNC` (default `false`). Restarts no longer trigger downloads.
- **On-demand control:** `POST /admin/sync_sources` and `POST /admin/check_updates` (admin auth) run them deliberately.
- **Staging-path bug:** the worker is told `/data/{id}_staging.owl`, but the ontologies dir mounts at `/data`, so the real path is `/data/{id}/{id}_staging.owl`. Fixed → indexing can actually read the file.
- **Index-when-missing:** the pipeline skipped indexing whenever the OWL MD5 was unchanged, even if **no ES index existed** — so never-indexed ontologies stayed empty. Now it only skips when an index already exists.

Tests: 81 pass (the 1 failure, `test_sparql_plain_query`, fails on main too — pre-existing).

**Out of scope (follow-up):** the `ontology_registry` vs `registered_servers` registry duality, and a fully separate reindex-from-existing-OWL endpoint. Related: #54 (central index creation + synonyms.raw).