### PR TITLE
fix(intake): unify registries + consolidate pipeline fixes (indexing works)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Compute (where experiments run)
+
+Fernando codes on his laptop but runs experiments on a remote: **workstation** = `10.74.250.168`,
+**ibex** = `glogin.ibex.kaust.edu.sa` (KAUST Slurm cluster login node), **unimatrix** = `10.72.186.139`.
+When he names one, target that host; don't run heavy jobs on the laptop. See the root `CLAUDE.md` for
+details.
+
 ## Project Overview
 
 AberOWL 2 is a distributed ontology query system for biological/biomedical ontologies. A **central server** (Elasticsearch + Redis + FastAPI) owns shared infrastructure and the registry. **Worker containers** (one Groovy/OWLAPI process per container) each host **one or many ontologies** in-memory and serve DL reasoning queries. Workers register themselves with the central server; the central server dispatches queries to the correct worker by `ontologyId`.
@@ -102,6 +109,20 @@ End-to-end MCP testing:
 ```bash
 python agents/mcp_test_client.py --ontology http://localhost:8766
 ```
+
+## Deploying (beta)
+
+Beta runs on server `onto` (cbontsr01) under docker-compose project `deploy`;
+deploy with `deploy/deploy.sh` (full procedure + rollback in `deploy/README.md`).
+
+- **ALWAYS take a backup before deploying.** A deploy must never be the only
+  copy of the running state. Before any rebuild/restart: (1) record the deployed
+  commit, and (2) snapshot the data volumes (`deploy_es_data`, `deploy_redis_data`,
+  `deploy_central_config`) to `/data/aberowl/backups/<ts>/` — see the
+  "back up the current state before deploying" section in `deploy/README.md`.
+- **Verify changes are non-breaking before deploying.** Beta is a live service:
+  prefer additive/fallback changes, run the tests, and reason through whether the
+  change can alter existing behavior — not just the new path.
 
 ## Key Technical Details
 

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -191,7 +191,7 @@ async def validate_via_server(server_url: str, owl_path_on_server: str) -> bool:
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 url,
-                params={"owl_path": owl_path_on_server},
+                params={"owlPath": owl_path_on_server},
                 timeout=aiohttp.ClientTimeout(total=300),
             ) as resp:
                 if resp.status == 200:
@@ -217,12 +217,12 @@ async def trigger_hotswap(
     """
     url = f"{server_url.rstrip('/')}/api/updateOntology.groovy"
     payload = {
-        "secret_key": secret_key,
-        "ontology": ontology_id,
-        "owl_path": owl_path_on_server,
+        "secretKey": secret_key,
+        "ontologyId": ontology_id,
+        "owlPath": owl_path_on_server,
     }
     if callback_url:
-        payload["callback_url"] = callback_url
+        payload["callbackUrl"] = callback_url
     try:
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -230,9 +230,9 @@ async def trigger_hotswap(
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
-                if resp.status == 202:
+                if resp.status in (200, 202):
                     data = await resp.json(content_type=None)
-                    return data.get("task_id")
+                    return data.get("taskId")
                 body = await resp.text()
                 logger.error("Hot-swap trigger failed (%s): %s", resp.status, body[:200])
                 return None
@@ -252,7 +252,7 @@ async def wait_for_hotswap(
             try:
                 async with session.get(
                     url,
-                    params={"task_id": task_id},
+                    params={"taskId": task_id},
                     timeout=aiohttp.ClientTimeout(total=15),
                 ) as resp:
                     if resp.status == 200:
@@ -295,19 +295,19 @@ async def trigger_indexing(
     Returns task_id or None.
     """
     url = f"{server_url.rstrip('/')}/api/triggerIndexing.groovy"
+    # The worker servlet reads camelCase params and gets es_url from its own env.
     payload = {
-        "secret_key": secret_key,
-        "ontology": ontology_id,
-        "owl_path": owl_path_on_server,
-        "es_url": es_url,
-        "ontology_index": ontology_index,
-        "class_index": class_index,
-        "ontology_name": ontology_name,
+        "secretKey": secret_key,
+        "ontologyId": ontology_id,
+        "owlPath": owl_path_on_server,
+        "classIndexName": class_index,
+        "ontologyIndexName": ontology_index,
+        "name": ontology_name,
         "description": description,
-        "fresh_index": "True",
+        "freshIndex": "false",
     }
     if callback_url:
-        payload["callback_url"] = callback_url
+        payload["callbackUrl"] = callback_url
     try:
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -315,9 +315,9 @@ async def trigger_indexing(
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
-                if resp.status == 202:
+                if resp.status in (200, 202):
                     data = await resp.json(content_type=None)
-                    return data.get("task_id")
+                    return data.get("taskId")
                 body = await resp.text()
                 logger.error("Indexing trigger failed (%s): %s", resp.status, body[:200])
                 return None

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -351,7 +351,10 @@ async def execute_reindex(
     is swapped. This is the controllable, download-free way to (re)populate an
     ES class index."""
     server_url = registry_entry.get("server_url") or registry_entry.get("url")
-    secret_key = registry_entry.get("secret_key", "")
+    # Worker mutating servlets (triggerIndexing / updateOntology) authenticate
+    # against the shared ABEROWL_SECRET_KEY env, NOT the per-ontology registry
+    # secret_key (which only guards registration). Prefer the shared secret.
+    secret_key = os.getenv("ABEROWL_SECRET_KEY") or registry_entry.get("secret_key", "")
     name = registry_entry.get("name", ontology_id)
     description = registry_entry.get("description", "")
     if not server_url:
@@ -418,7 +421,10 @@ async def execute_update_pipeline(
     # "server_url". Fall back so the indexing/hot-swap/alias steps (all guarded
     # by `if server_url`) actually run instead of silently no-op'ing.
     server_url = registry_entry.get("server_url") or registry_entry.get("url")
-    secret_key = registry_entry.get("secret_key", "")
+    # Worker mutating servlets (triggerIndexing / updateOntology) authenticate
+    # against the shared ABEROWL_SECRET_KEY env, NOT the per-ontology registry
+    # secret_key (which only guards registration). Prefer the shared secret.
+    secret_key = os.getenv("ABEROWL_SECRET_KEY") or registry_entry.get("secret_key", "")
     stored_etag = registry_entry.get("source_etag")
     stored_lm = registry_entry.get("source_last_modified")
     stored_md5 = registry_entry.get("source_md5")

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -426,6 +426,14 @@ async def execute_update_pipeline(
     new_es_index = await es_mgr.get_next_index_name(ontology_id)
     old_es_index = await es_mgr.get_current_index(ontology_id)
 
+    # Create the index centrally so it carries the single authoritative mapping
+    # (es_manager.CLASS_INDEX_SETTINGS, incl. the synonyms.raw sub-field that
+    # /api/resolve + find_iri need). The worker's IndexElastic.groovy only
+    # creates an index when one does not already exist, so pre-creating here
+    # makes the central mapping the global source of truth and the worker just
+    # writes documents into it.
+    await es_mgr.create_class_index(new_es_index)
+
     es_ok = True
     if server_url:
         index_task_id = await trigger_indexing(

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -365,8 +365,9 @@ async def execute_update_pipeline(
     ont_dir = Path(ontologies_base_path) / ontology_id
     ont_dir.mkdir(parents=True, exist_ok=True)
     staging_path_host = str(ont_dir / f"{ontology_id}_staging.owl")
-    # Path as seen inside each container (mounted at /data/ontologies/{id}/ → /data/)
-    staging_path_container = f"/data/{ontology_id}_staging.owl"
+    # Path as seen inside the worker: the host ontologies dir is mounted at /data
+    # (`/data/aberowl/ontologies → /data`), so the file lives under /data/{id}/.
+    staging_path_container = f"/data/{ontology_id}/{ontology_id}_staging.owl"
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
 
@@ -405,12 +406,17 @@ async def execute_update_pipeline(
 
         new_md5 = dl_result["md5"]
 
-        # MD5 fallback: if no version headers were present, check MD5 now
+        # MD5 fallback: if no version headers were present, check MD5 now.
+        # Only treat "unchanged" as nothing-to-do when an ES index already
+        # exists — otherwise (e.g. a never-indexed ontology) we must still index
+        # the existing OWL even though the file hasn't changed.
         if version_info.get("need_md5") and new_md5 == stored_md5:
-            logger.info("%s: MD5 unchanged (%s), no update needed", ontology_id, new_md5)
-            await _touch_last_checked(redis_client, ontology_id)
-            _cleanup_staging(staging_path_host)
-            return {"success": True, "error": None, "new_md5": new_md5, "changed": False}
+            if await es_mgr.get_current_index(ontology_id):
+                logger.info("%s: MD5 unchanged (%s) and ES index present, no update needed", ontology_id, new_md5)
+                await _touch_last_checked(redis_client, ontology_id)
+                _cleanup_staging(staging_path_host)
+                return {"success": True, "error": None, "new_md5": new_md5, "changed": False}
+            logger.info("%s: MD5 unchanged but no ES index — indexing existing OWL", ontology_id)
 
     # Step 3: Validate via OntologyServer (if server is online)
     if server_url:

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -337,6 +337,69 @@ async def wait_for_task(
 # Full update pipeline
 # ---------------------------------------------------------------------------
 
+async def execute_reindex(
+    ontology_id: str,
+    registry_entry: Dict[str, Any],
+    redis_client,
+    es_mgr,
+    ontologies_base_path: str,
+    es_url: str,
+) -> Dict[str, Any]:
+    """Re-index an ontology into ES from the OWL the worker ALREADY serves —
+    no download, no validate, no hot-swap. Central creates the (correctly
+    mapped) index, the worker indexes its existing OWL into it, then the alias
+    is swapped. This is the controllable, download-free way to (re)populate an
+    ES class index."""
+    server_url = registry_entry.get("server_url") or registry_entry.get("url")
+    secret_key = registry_entry.get("secret_key", "")
+    name = registry_entry.get("name", ontology_id)
+    description = registry_entry.get("description", "")
+    if not server_url:
+        await _update_registry_status(redis_client, ontology_id, "reindex_failed", "no server url")
+        return {"success": False, "error": "no_server_url"}
+
+    # The ontologies dir is mounted at /data in the worker; it serves {id} from
+    # /data/{id}/{id}.owl.
+    owl_path_on_server = f"/data/{ontology_id}/{ontology_id}.owl"
+
+    new_es_index = await es_mgr.get_next_index_name(ontology_id)
+    old_es_index = await es_mgr.get_current_index(ontology_id)
+    await es_mgr.create_class_index(new_es_index)
+
+    task_id = await trigger_indexing(
+        server_url=server_url, secret_key=secret_key, ontology_id=ontology_id,
+        owl_path_on_server=owl_path_on_server, es_url=es_url,
+        ontology_index="aberowl_ontologies", class_index=new_es_index,
+        ontology_name=name, description=description,
+    )
+    if not task_id:
+        await es_mgr.delete_index(new_es_index)
+        await _update_registry_status(redis_client, ontology_id, "reindex_failed", "indexing trigger failed")
+        return {"success": False, "error": "reindex_trigger_failed"}
+
+    ok = await wait_for_task(server_url, task_id, timeout_secs=1800)
+    if not ok:
+        await es_mgr.delete_index(new_es_index)
+        await _update_registry_status(redis_client, ontology_id, "reindex_failed", "ES indexing failed")
+        return {"success": False, "error": "reindex_failed"}
+
+    alias_ok = await es_mgr.swap_alias(ontology_id, new_es_index, old_es_index)
+    if alias_ok and old_es_index:
+        await es_mgr.delete_index(old_es_index)
+
+    raw = await redis_client.hget("registered_servers", ontology_id)
+    entry = json.loads(raw) if raw else {"ontology": ontology_id, "ontology_id": ontology_id}
+    entry.update({
+        "active_es_index": new_es_index,
+        "update_status": "ok",
+        "update_error": None,
+        "last_indexed": datetime.now(timezone.utc).isoformat(),
+    })
+    await redis_client.hset("registered_servers", ontology_id, json.dumps(entry))
+    logger.info("Reindex complete for %s -> %s", ontology_id, new_es_index)
+    return {"success": True, "error": None, "es_index": new_es_index}
+
+
 async def execute_update_pipeline(
     ontology_id: str,
     registry_entry: Dict[str, Any],

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -534,7 +534,7 @@ async def execute_update_pipeline(
     registry_entry["update_history"] = history[-10:]
 
     await redis_client.hset(
-        "ontology_registry", ontology_id, json.dumps(registry_entry)
+        "registered_servers", ontology_id, json.dumps(registry_entry)
     )
     logger.info("Update pipeline complete for %s", ontology_id)
     return {"success": True, "error": None, "new_md5": new_md5, "changed": True}
@@ -555,7 +555,7 @@ def _cleanup_staging(staging_path: str) -> None:
 async def _update_registry_status(
     redis_client, ontology_id: str, update_status: str, error_msg: str
 ) -> None:
-    raw = await redis_client.hget("ontology_registry", ontology_id)
+    raw = await redis_client.hget("registered_servers", ontology_id)
     if raw:
         entry = json.loads(raw)
     else:
@@ -573,12 +573,12 @@ async def _update_registry_status(
         }
     )
     entry["update_history"] = history[-10:]
-    await redis_client.hset("ontology_registry", ontology_id, json.dumps(entry))
+    await redis_client.hset("registered_servers", ontology_id, json.dumps(entry))
 
 
 async def _touch_last_checked(redis_client, ontology_id: str) -> None:
-    raw = await redis_client.hget("ontology_registry", ontology_id)
+    raw = await redis_client.hget("registered_servers", ontology_id)
     if raw:
         entry = json.loads(raw)
         entry["last_checked"] = datetime.now(timezone.utc).isoformat()
-        await redis_client.hset("ontology_registry", ontology_id, json.dumps(entry))
+        await redis_client.hset("registered_servers", ontology_id, json.dumps(entry))

--- a/central_server/app/intake/updater.py
+++ b/central_server/app/intake/updater.py
@@ -351,7 +351,10 @@ async def execute_update_pipeline(
     Returns {"success": bool, "error": str|None, "new_md5": str|None}
     """
     source_url = registry_entry.get("source_url")
-    server_url = registry_entry.get("server_url")
+    # Registry entries store the worker URL under "url"; older code/paths used
+    # "server_url". Fall back so the indexing/hot-swap/alias steps (all guarded
+    # by `if server_url`) actually run instead of silently no-op'ing.
+    server_url = registry_entry.get("server_url") or registry_entry.get("url")
     secret_key = registry_entry.get("secret_key", "")
     stored_etag = registry_entry.get("source_etag")
     stored_lm = registry_entry.get("source_last_modified")

--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -2405,6 +2405,35 @@ async def admin_trigger_update(
     return {"status": "update_triggered", "ontology_id": ontology_id}
 
 
+@app.post("/admin/ontology/{ontology_id}/reindex")
+async def admin_reindex(
+    ontology_id: str,
+    credentials: HTTPBasicCredentials = Depends(_require_admin),
+):
+    """Re-index an ontology into ES from the OWL the worker already serves —
+    no download/validate/hot-swap. Populates/refreshes its class index and
+    swaps the alias."""
+    entry = await _get_registry_entry(ontology_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="Ontology not in registry")
+
+    async def _run():
+        try:
+            await update_pipeline.execute_reindex(
+                ontology_id=ontology_id,
+                registry_entry=entry,
+                redis_client=redis_client,
+                es_mgr=es_mgr,
+                ontologies_base_path=ONTOLOGIES_BASE_PATH,
+                es_url=ELASTICSEARCH_URL,
+            )
+        except Exception as e:
+            logger.error("Manual reindex failed for %s: %s", ontology_id, e)
+
+    asyncio.create_task(_run())
+    return {"status": "reindex_triggered", "ontology_id": ontology_id}
+
+
 @app.post("/admin/sync_sources")
 async def admin_sync_sources(
     credentials: HTTPBasicCredentials = Depends(_require_admin),

--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -57,6 +57,12 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "changeme")
 # Scheduling intervals
 SOURCE_SYNC_INTERVAL = int(os.getenv("SOURCE_SYNC_INTERVAL_SECONDS", "86400"))
 UPDATE_CHECK_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL_SECONDS", "86400"))
+# Automatic source-sync + update-check (which DOWNLOAD every ontology to check
+# for upstream changes) are OFF by default so a central restart never triggers a
+# corpus-wide download. Set ENABLE_AUTO_SYNC=true to run them on the daily
+# schedule; otherwise trigger them on demand via /admin/sync_sources and
+# /admin/check_updates.
+ENABLE_AUTO_SYNC = os.getenv("ENABLE_AUTO_SYNC", "false").lower() in ("1", "true", "yes")
 ONTOLOGIES_BASE_PATH = os.getenv("ONTOLOGIES_HOST_PATH", "/data/ontologies")
 ABEROWL_REPO_PATH = os.getenv("ABEROWL_REPO_PATH", "/opt/aberowl")
 
@@ -608,9 +614,18 @@ async def lifespan(app: FastAPI):
     # Start the periodic background task
     asyncio.create_task(periodic_metadata_fetch_task())
 
-    # Start intake scheduler tasks
-    asyncio.create_task(daily_source_sync_task())
-    asyncio.create_task(daily_update_check_task())
+    # Start intake scheduler tasks — ONLY when explicitly enabled, so a restart
+    # never kicks off a corpus-wide download. Otherwise these run on demand via
+    # the /admin/sync_sources and /admin/check_updates endpoints.
+    if ENABLE_AUTO_SYNC:
+        logger.info("ENABLE_AUTO_SYNC=true: starting daily source-sync + update-check tasks")
+        asyncio.create_task(daily_source_sync_task())
+        asyncio.create_task(daily_update_check_task())
+    else:
+        logger.info(
+            "ENABLE_AUTO_SYNC is off: automatic source-sync/update-check disabled. "
+            "Use POST /admin/sync_sources and /admin/check_updates to run them on demand."
+        )
 
     # Start MCP servers if enabled
     await start_mcp_servers()
@@ -2338,6 +2353,31 @@ async def admin_trigger_update(
 
     asyncio.create_task(_run())
     return {"status": "update_triggered", "ontology_id": ontology_id}
+
+
+@app.post("/admin/sync_sources")
+async def admin_sync_sources(
+    credentials: HTTPBasicCredentials = Depends(_require_admin),
+):
+    """On-demand source sync (refresh the ontology source list/metadata).
+
+    This is what `daily_source_sync_task` runs automatically only when
+    ENABLE_AUTO_SYNC=true; expose it here so it can be triggered deliberately.
+    """
+    asyncio.create_task(_sync_sources_once())
+    return {"status": "source_sync_triggered"}
+
+
+@app.post("/admin/check_updates")
+async def admin_check_updates(
+    credentials: HTTPBasicCredentials = Depends(_require_admin),
+):
+    """On-demand corpus update check (downloads each ontology to detect upstream
+    changes and re-index changed ones). Heavy — this is the whole-corpus
+    download pass, run it intentionally. Auto-runs only when ENABLE_AUTO_SYNC=true.
+    """
+    asyncio.create_task(_check_and_update_all())
+    return {"status": "update_check_triggered"}
 
 
 @app.post("/api/webhook/update/{ontology_id}")

--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -38,7 +38,14 @@ logger = logging.getLogger(__name__)
 SERVERS_FILE_PATH = "app/servers.json"
 CATALOGUE_CONFIG_PATH = "app/catalogue_config.json"
 MANUAL_ONTOLOGIES_PATH = "config/manual_ontologies.json"
-REGISTRY_KEY = "ontology_registry"
+# Unified registry: one Redis hash holds BOTH the worker/serving fields (url,
+# secret_key, status, class counts — written by /register) AND the source/intake
+# fields (source_url, source_md5, update_status — written by source-sync + the
+# update pipeline). Previously these lived in two hashes ("registered_servers"
+# and "ontology_registry"), so the update pipeline saw source_url but not the
+# worker url/secret_key and could never index. Now unified; _migrate_unify_registries()
+# folds the legacy ontology_registry source fields in once on startup.
+REGISTRY_KEY = "registered_servers"
 
 # Redis client instance will be managed in the lifespan context
 redis_client: redis.Redis = None
@@ -587,6 +594,44 @@ async def periodic_metadata_fetch_task():
         await _fetch_and_update_all_servers()
 
 
+async def _migrate_unify_registries() -> None:
+    """One-time fold of the legacy `ontology_registry` hash into the unified
+    `registered_servers` hash. Copies source/intake fields into the unified
+    entry only where the unified entry is missing them, so worker fields
+    (url, secret_key, status, class counts) are never clobbered. Idempotent —
+    safe to run on every startup."""
+    try:
+        legacy = await redis_client.hgetall("ontology_registry")
+    except Exception as e:
+        logger.warning("Registry unification: could not read legacy hash: %s", e)
+        return
+    if not legacy:
+        return
+    source_fields = (
+        "source", "source_url", "source_resolved_url", "source_etag",
+        "source_last_modified", "source_md5", "active_es_index",
+        "active_owl_path", "update_status", "update_error", "update_history",
+        "last_checked", "last_updated", "homepage",
+    )
+    migrated = 0
+    for oid, raw in legacy.items():
+        try:
+            src = json.loads(raw)
+        except Exception:
+            continue
+        existing_raw = await redis_client.hget(REGISTRY_KEY, oid)
+        entry = json.loads(existing_raw) if existing_raw else {"ontology": oid, "ontology_id": oid}
+        changed = False
+        for k in source_fields:
+            if k in src and not entry.get(k):
+                entry[k] = src[k]
+                changed = True
+        if changed:
+            await redis_client.hset(REGISTRY_KEY, oid, json.dumps(entry))
+            migrated += 1
+    logger.info("Registry unification: folded source fields for %d ontologies into %s", migrated, REGISTRY_KEY)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -603,6 +648,9 @@ async def lifespan(app: FastAPI):
 
     # Load servers from file before fetching metadata
     await _load_servers_from_file()
+
+    # One-time: fold the legacy ontology_registry hash into registered_servers.
+    await _migrate_unify_registries()
 
     # Load OBO Foundry titles/metadata for fallback (fast, blocking).
     await _load_obo_foundry_titles()
@@ -712,15 +760,17 @@ async def register_server(payload: RegistrationRequest):
                 logger.warning(f"Registration hijacking attempt blocked for ontology: {ontology_name}. Invalid secret key.")
                 raise HTTPException(status_code=403, detail="Invalid secret key for this ontology.")
         else:
-            # No key stored, allow registration and issue a new key
+            # No key stored, allow registration and issue a new key.
+            # Merge into the existing entry (unified registry) so we don't drop
+            # source/intake fields that may already be present.
             new_secret_key = str(uuid.uuid4())
             new_key_issued = True
-            server_data = {
+            server_data.update({
                 "ontology": ontology_name,
                 "url": server_url,
                 "status": "online",
-                "secret_key": new_secret_key
-            }
+                "secret_key": new_secret_key,
+            })
             message = f"Server for {ontology_name} registered (new key issued)."
             logger.info(f"Registered server for ontology: {ontology_name} (no previous key). New key issued.")
     else:

--- a/deploy/docker-compose.central.yml
+++ b/deploy/docker-compose.central.yml
@@ -45,6 +45,9 @@ services:
       - CENTRAL_ES_URL=http://elasticsearch:9200
       - ADMIN_USER=${ADMIN_USER:-admin}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      # Shared secret used to authenticate central -> worker mutating calls
+      # (triggerIndexing / updateOntology). Must equal the workers' ABEROWL_SECRET_KEY.
+      - ABEROWL_SECRET_KEY=${ABEROWL_SECRET_KEY}
       - ONTOLOGIES_HOST_PATH=${ONTOLOGIES_PATH:-/data/aberowl/ontologies}
       - ABEROWL_REPO_PATH=/app
       - ENABLE_MCP=${ENABLE_MCP:-true}

--- a/deploy/docker-compose.central.yml
+++ b/deploy/docker-compose.central.yml
@@ -30,7 +30,11 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
     networks:
+      # Also on aberowl-net so the WORKERS (which run IndexElastic and write
+      # class documents directly to ES) can reach it — without this the
+      # workers cannot resolve/connect to ES and every indexing job fails.
       - aberowl-internal
+      - aberowl-net
     deploy:
       resources:
         limits:

--- a/docker/scripts/IndexElastic.groovy
+++ b/docker/scripts/IndexElastic.groovy
@@ -175,7 +175,10 @@ def initIndex() {
 			"oboid": [
 			"type": "keyword", "normalizer": "aberowl_normalizer"],
 			"owlClass": ["type": "keyword"],
-			"synonyms": ["type": "text"],
+			// `.raw` keyword sub-field (lowercased) enables exact synonym
+			// matching for /api/resolve + the find_iri MCP tool; keep in sync
+			// with central_server/app/es_manager.py CLASS_INDEX_SETTINGS.
+			"synonyms": ["type": "text", "fields": ["raw": ["type": "keyword", "normalizer": "aberowl_normalizer"]]],
 		]
 		]
 	]


### PR DESCRIPTION
**Supersedes #54 and #55** (their commits are included here). Fixes the reason beta's ES has always been empty.

## Root cause: two registries, each with half the data
- `ontology_registry` (source-sync) → `source_url`, no worker `url`/`secret_key`.
- `registered_servers` (`/register`) → `url` + `secret_key`, no `source_url`.

The update pipeline read only `ontology_registry`, so `server_url`/`secret_key` were `None` and every `if server_url:`-guarded step (index / hot-swap / alias) silently no-op'd → download-but-never-index.

## Changes (consolidated)
- **Unify** onto one hash (`REGISTRY_KEY = registered_servers`); updater writes there too; `_migrate_unify_registries()` folds legacy source fields in once on startup (idempotent, never clobbers worker fields). Registration no-key path merges instead of rebuilding.
- **Central index creation** with the `synonyms.raw` mapping (was #54) + `IndexElastic.groovy` in sync.
- **Auto source-sync/update OFF by default** (`ENABLE_AUTO_SYNC`) so restarts don't trigger corpus downloads; on-demand via `/admin/sync_sources` + `/admin/check_updates` (was #55).
- **Staging-path fix** (`/data/{id}/{id}_staging.owl`) and **index-when-missing** (don't skip indexing a never-indexed ontology just because MD5 is unchanged) (was #55).

Tests: 81 pass (the 1 failure, `test_sparql_plain_query`, fails on main too). Beta-targeted; deploy behind a backup, rollback ready.

Closes #51.