### PR TITLE
fix(registry): migration must not create worker-less entries

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -620,7 +620,14 @@ async def _migrate_unify_registries() -> None:
         except Exception:
             continue
         existing_raw = await redis_client.hget(REGISTRY_KEY, oid)
-        entry = json.loads(existing_raw) if existing_raw else {"ontology": oid, "ontology_id": oid}
+        if not existing_raw:
+            # Only ENRICH ontologies that are actually hosted (already have a
+            # worker entry). Do NOT create worker-less entries for source-only
+            # ontologies — they never get served, and the periodic metadata
+            # fetch (which fans out to every registry entry) then fails on them
+            # every cycle, degrading browsing.
+            continue
+        entry = json.loads(existing_raw)
         changed = False
         for k in source_fields:
             if k in src and not entry.get(k):


### PR DESCRIPTION
The registry-unification migration (`_migrate_unify_registries`) created new `registered_servers` entries for **source-only** ontologies (present in the legacy `ontology_registry` with a `source_url` but never hosted by a worker). That inflated the registry **861 → 994** with 133 URL-less entries.

The 60s periodic metadata fetch (`_fetch_and_update_all_servers`) fans out to *every* registry entry, so it now fails on those 133 every cycle → connection-pool exhaustion + degraded browsing (the reappeared slowness).

**Fix:** the migration now only *enriches* ontologies that already have a worker entry; it never creates worker-less ones. So a restart/redeploy won't re-add the 133. (The 133 already in beta's registry are removed as a one-off data cleanup.)

Follow-ups (separate): bound the metadata-fetch concurrency + skip URL-less/offline entries; fix the public `/api/` nginx route.