### PR TITLE
fix(security): stop leaking worker secret_key and internal URL from getOntology

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -639,6 +639,39 @@ async def _migrate_unify_registries() -> None:
     logger.info("Registry unification: folded source fields for %d ontologies into %s", migrated, REGISTRY_KEY)
 
 
+# Fields from a registry entry that are safe to expose to unauthenticated API
+# clients. This is an ALLOW-LIST (not a denylist) so that any new internal or
+# ops field added to a registry entry stays private by default and never leaks.
+# In particular this must never include `secret_key` (authorizes the workers'
+# mutating endpoints), the internal worker `url`, or `server_url`.
+_PUBLIC_ONTOLOGY_FIELDS = frozenset({
+    # identity / naming
+    "id", "ontology", "ontology_id", "title", "name", "description",
+    # provenance / versioning
+    "version_info", "version_iri", "license", "default_namespace",
+    "obo_format_version", "home_page", "homepage", "documentation",
+    "publication", "creators", "keywords",
+    # serving state (safe: coarse status only, no url)
+    "status", "reasoner_type",
+    # class/property/example counts and samples
+    "class_count", "property_count", "object_property_count",
+    "individual_count", "example_classes", "example_class",
+})
+
+
+def _public_ontology_view(entry: dict) -> dict:
+    """Return only the public allow-listed fields of a registry entry.
+
+    Registry entries stored in Redis carry internal/ops fields — notably
+    `secret_key` (authorizes worker mutation), the internal worker `url`, and
+    `server_url` — that must NEVER reach API clients. Client-facing handlers
+    that surface registry entries must pass them through this filter.
+    """
+    if not isinstance(entry, dict):
+        return {}
+    return {k: v for k, v in entry.items() if k in _PUBLIC_ONTOLOGY_FIELDS}
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -988,9 +1021,13 @@ async def dl_query_all(request: Request):
 
 @app.get("/api/servers")
 async def get_servers():
-    """Returns a list of registered servers and their metadata from Redis."""
+    """Returns a list of registered servers and their public metadata.
+
+    Filtered through the public allow-list so internal fields (secret_key,
+    internal worker url, server_url, ops status) are never exposed.
+    """
     server_data_json = await redis_client.hvals("registered_servers")
-    servers = [json.loads(s) for s in server_data_json]
+    servers = [_public_ontology_view(json.loads(s)) for s in server_data_json]
     return servers
 
 
@@ -1012,12 +1049,17 @@ async def list_ontologies_api():
 
 @app.get("/api/getOntology")
 async def get_ontology_api(ontology: str = Query(...)):
-    """Return full metadata for a single ontology."""
+    """Return public metadata for a single ontology.
+
+    The stored registry entry carries internal fields (secret_key, internal
+    worker url, server_url, ops status). We serialize ONLY the public
+    allow-list via _public_ontology_view so those are never leaked.
+    """
     server_data_json = await redis_client.hvals("registered_servers")
     servers = [json.loads(s) for s in server_data_json]
     for s in servers:
         if s.get("ontology", "").lower() == ontology.lower():
-            return s
+            return _public_ontology_view(s)
     raise HTTPException(status_code=404, detail=f"Ontology not found: {ontology}")
 
 
@@ -1545,11 +1587,12 @@ async def get_artefacts(
                 "@value": server.get("description", "")
             },
             "dcat:landingPage": {
-                "@id": server.get("url", ""),
+                # Public home page only — never the internal worker url.
+                "@id": server.get("home_page", server.get("homepage", "")),
                 "@type": "foaf:Document"
             }
         }
-        
+
         # Add optional fields if available
         if "keywords" in server:
             artefact["dcat:keyword"] = server["keywords"]
@@ -1639,7 +1682,8 @@ async def get_artefact(
             "@value": server.get("description", "")
         },
         "dcat:landingPage": {
-            "@id": server.get("url", ""),
+            # Public home page only — never the internal worker url.
+            "@id": server.get("home_page", server.get("homepage", "")),
             "@type": "foaf:Document"
         },
         "dcterms:issued": datetime.utcnow().isoformat(),
@@ -1695,7 +1739,8 @@ async def get_artefact_distributions(
             "@value": f"Latest distribution of {server.get('title', artefact_id)}"
         },
         "dcat:accessURL": {
-            "@id": server.get("url", ""),
+            # Public landing/access point only — never the internal worker url.
+            "@id": server.get("home_page", server.get("homepage", "")),
             "@type": "rdfs:Resource"
         },
         "dcterms:format": "application/rdf+xml",
@@ -1761,7 +1806,8 @@ async def get_artefact_latest_distribution(
             "@value": f"Latest distribution of {server.get('title', artefact_id)}"
         },
         "dcat:accessURL": {
-            "@id": server.get("url", ""),
+            # Public landing/access point only — never the internal worker url.
+            "@id": server.get("home_page", server.get("homepage", "")),
             "@type": "rdfs:Resource"
         },
         "dcterms:format": "application/rdf+xml",

--- a/central_server/tests/test_public_ontology_view.py
+++ b/central_server/tests/test_public_ontology_view.py
@@ -1,0 +1,103 @@
+"""Security regression tests for registry-entry serialization.
+
+`_public_ontology_view` is the allow-list filter every client-facing handler
+must run registry entries through. The public REST API previously leaked the
+worker `secret_key` (which authorizes the workers' mutating endpoints) and the
+internal worker `url` / `server_url` from `GET /api/getOntology`. These tests
+lock in that those fields can never be serialized to clients.
+
+Run: `python -m pytest central_server/tests/test_public_ontology_view.py`
+or standalone: `python central_server/tests/test_public_ontology_view.py`.
+"""
+
+import importlib.util
+import os
+import sys
+
+# Import _public_ontology_view from app/main.py without importing the whole
+# FastAPI app (which needs Redis/ES). We load the module source and exec only
+# the helper + its allow-list, avoiding heavy import-time side effects.
+_APP_MAIN = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "app", "main.py"
+)
+
+
+def _load_helper():
+    import ast
+
+    with open(_APP_MAIN) as fh:
+        tree = ast.parse(fh.read())
+    wanted = {"_PUBLIC_ONTOLOGY_FIELDS", "_public_ontology_view"}
+    ns = {"frozenset": frozenset}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            getattr(t, "id", None) in wanted for t in node.targets
+        ):
+            exec(compile(ast.Module([node], []), _APP_MAIN, "exec"), ns)
+        elif isinstance(node, ast.FunctionDef) and node.name in wanted:
+            exec(compile(ast.Module([node], []), _APP_MAIN, "exec"), ns)
+    return ns["_public_ontology_view"]
+
+
+_public_ontology_view = _load_helper()
+
+# A realistic registry entry as stored in the `registered_servers` Redis hash.
+_ENTRY = {
+    "ontology": "GO",
+    "title": "Gene Ontology",
+    "description": "An ontology of gene function.",
+    "version_info": "2024-01-01",
+    "license": "CC BY 4.0",
+    "home_page": "http://geneontology.org",
+    "status": "online",
+    "class_count": 50000,
+    "property_count": 12,
+    # --- internal fields that MUST NOT leak ---
+    "secret_key": "d34db33f-super-secret",
+    "url": "http://10.254.146.227:8084/",
+    "server_url": "http://10.254.146.227:8084/",
+    "update_status": "ok",
+    "update_error": "",
+}
+
+_FORBIDDEN = ("secret_key", "url", "server_url", "update_status", "update_error")
+
+
+def test_strips_all_internal_fields():
+    view = _public_ontology_view(_ENTRY)
+    for field in _FORBIDDEN:
+        assert field not in view, f"public view leaked internal field: {field}"
+
+
+def test_keeps_public_fields():
+    view = _public_ontology_view(_ENTRY)
+    for field in (
+        "ontology", "title", "description", "version_info", "license",
+        "home_page", "status", "class_count", "property_count",
+    ):
+        assert view.get(field) == _ENTRY[field], f"public field dropped: {field}"
+
+
+def test_allow_list_blocks_new_fields_by_default():
+    # A field nobody has allow-listed yet must not leak.
+    entry = dict(_ENTRY, brand_new_internal_token="leak-me")
+    view = _public_ontology_view(entry)
+    assert "brand_new_internal_token" not in view
+
+
+def test_non_dict_is_safe():
+    assert _public_ontology_view(None) == {}
+    assert _public_ontology_view("not a dict") == {}
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Closes #64

## The leak

`GET /api/getOntology?ontology=<id>` returned the **raw ontology registry record** straight from Redis. That record carries internal fields that must never reach clients:

- **`secret_key`** — the per-ontology registry key.
- the internal worker **`url`** (e.g. `http://10.254.146.227:8084/`) and/or **`server_url`**.

`GET /api/listOntologies` was already clean (id/title/status only). Verified against live prod `http://aber-owl.net` before the fix.

## What the leaked `secret_key` actually is

**Corrected 2026-07-16** — an earlier revision of this PR claimed the leaked key authorizes the workers' mutating endpoints (`addOntology`/`removeOntology`/`updateOntology`). **That was wrong.** There are two unrelated secrets:

| | Registry `secret_key` (**leaked**) | Worker `ABEROWL_SECRET_KEY` (**not leaked**) |
|---|---|---|
| Shape | uuid4, 36 chars (`main.py:785`) | `token_hex(32)`, 64 hex chars |
| Generated by | central, per **ontology**, at `POST /register` | env file, per **worker** (`launch_workers.py:84`) |
| Stored in | the Redis registry entry | the worker container's env only |
| Authorizes | re-registration + webhook update trigger | the worker's Groovy mutating servlets |

Verified on live prod: the registry key is 36 chars with 4 dashes; the worker env key is 64 hex chars; **the two values are different**. The workers' credentials were never exposed by this endpoint.

## Real impact

The registry key authorizes exactly two things:

1. **Re-registration** (`main.py:754-768`) — `POST /register` with `{ontology, url, secret_key}` on an existing entry overwrites its worker `url`. **This is the serious one: an attacker holding the leaked key can repoint an ontology at a worker they control, and central will dispatch DL reasoning queries there and return attacker-controlled results to users.**
2. **Webhook update trigger** (`main.py:2485`) — `X-Webhook-Secret` forces an update-pipeline run for that ontology (forced re-download / DoS vector).

The internal `url` leak is reconnaissance value only — the worker addresses are private `10.x` and not internet-routable.

## The fix (allow-list serialization)

Added `_public_ontology_view(entry: dict) -> dict` — an **allow-list** filter returning only public fields (id / ontology / ontology_id, title, description, version_info, version_iri, license, default_namespace, obo_format_version, home_page, documentation, publication, creators, keywords, status, reasoner_type, and class/property/individual counts + examples). Everything else — `secret_key`, `url`, `server_url`, `update_status`, `update_error`, any future internal field — is dropped **by default** because it's an allow-list, not a denylist.

Applied to the client-facing endpoints that surfaced registry entries:

- `GET /api/getOntology` — now returns `_public_ontology_view(entry)`.
- `GET /api/servers` — now maps every entry through `_public_ontology_view`.
- FAIR `/artefacts*` endpoints — stopped exposing the internal worker `url` in `dcat:landingPage` / `dcat:accessURL`; they now use the public `home_page`.

Audited and confirmed already-safe (no change needed): `listOntologies`, `getStats`, `getStatuses`, `search_all`, `resolve`, `queryNames`, `queryOntologies`, `dlquery_all` (uses worker url internally, returns only query results). `/admin` intentionally keeps the full ops view and is auth-gated behind `_require_admin`.

## Verification

- `central_server/tests/test_public_ontology_view.py`: asserts `secret_key` / `url` / `server_url` / `update_status` / `update_error` are stripped, public fields survive, unknown fields don't leak, and non-dict input is safe.
- Non-breaking check (2026-07-16): no consumer reads the stripped fields. The SPA never references `.url`/`.server_url`/`.secret_key`; `mcp_ontology_server.py` passes the JSON through; the prod tooling (`reindex_missing.py`, `split_deploy.py`) reads only `ontology` and `status`, both still in the allow-list; internal dispatch reads Redis directly, not `/api/servers`.

## Required ops follow-up

**Deploy this first, then rotate.** Rotating while the endpoint still leaks would expose the new keys too.

Rotation is **Redis-only**: replace `secret_key` on each registry entry with a fresh uuid4. **No worker restarts, no ontology reloads, no downtime** — the workers' `ABEROWL_SECRET_KEY` is unaffected, prod's workers don't self-register (`ABEROWL_REGISTER` unset → defaults false), and `split_deploy.py` discarded the keys central issued it, so no legitimate client holds them.