### PR TITLE
docs: clarify self-host ontology input (files + sources.txt combine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,25 @@ docker compose -f deploy/docker-compose.selfhost.yml up
 #   web / API -> http://localhost:8000
 #   MCP       -> http://localhost:8766/mcp
 
-# your own ontologies — point at a folder of .owl files and/or a sources.txt of URLs:
+# your own ontologies — point at one folder:
 ONTOLOGIES_DIR=./my-ontologies docker compose -f deploy/docker-compose.selfhost.yml up
 ```
 
-Ontology input, simplest first: drop `.owl` **files** in the folder; list **URLs** in a
-`sources.txt` (e.g. OBO Foundry PURLs) to download on startup; or give an
-`ontologies.config.json` for full control (id + reasoner per ontology). It brings up
-Elasticsearch, Redis, the central server, and one worker on an internal network,
-loads and classifies each ontology, and indexes it for search — no cross-host wiring.
+You feed ontologies to that one folder in two ways that **work together in the same
+folder** — drop `.owl` **files** in directly, and/or add a `sources.txt` listing **URLs**
+to download on startup (e.g. OBO Foundry PURLs). Both are loaded:
+
+```
+my-ontologies/
+  pizza.owl          # a local file
+  sources.txt        # one line:  bfo  http://purl.obolibrary.org/obo/bfo.owl
+```
+
+The example above loads **both** pizza (from the file) and bfo (downloaded from the URL).
+For per-ontology control instead, add an `ontologies.config.json` (authoritative — it
+replaces the files/`sources.txt` scan). It brings up Elasticsearch, Redis, the central
+server, and one worker on an internal network, then loads, classifies, and indexes each
+ontology for search — no cross-host wiring.
 
 See [`deploy/SELF_HOSTING.md`](deploy/SELF_HOSTING.md) and the ready-to-run
 [`examples/selfhost/`](examples/selfhost/).

--- a/deploy/SELF_HOSTING.md
+++ b/deploy/SELF_HOSTING.md
@@ -23,17 +23,33 @@ so docker DNS resolves the names and **none of the cross-host IP wiring the prod
 cluster needed applies here**. That is the whole reason a turnkey single-host path is
 feasible with little new code.
 
-## How you feed in ontologies (simplest first)
+## How you feed in ontologies
 
-Point `ONTOLOGIES_DIR` at a folder (defaults to the bundled example). The folder can hold:
+Point `ONTOLOGIES_DIR` at **one** folder. You supply ontologies to it in two ways that
+work **together in the same folder** — you don't pick one:
 
-1. **Bare files** — drop `myont.owl` in; id becomes `myont`, reasoner ELK. Zero config.
-2. **Web sources** — a `sources.txt`, one `[id] URL [reasoner]` per line, downloaded on startup.
-3. **Full control** — an `ontologies.config.json` (authoritative): `[{"id","path"|"url","reasoner"}]`.
+- **Files** — drop `.owl` files in directly. Each file's id comes from its name
+  (`myont.owl` → `myont`), reasoner defaults to ELK.
+- **URLs** — add a `sources.txt` listing ontologies to download on startup, one
+  `[id] URL [reasoner]` per line (e.g. OBO Foundry PURLs; `#` comments allowed).
 
-The `ontology-prepare` step turns whichever of these it finds into a single canonical
-`ontologies.json` that the worker loads, so the three modes share one code path
-(`deploy/selfhost_init.py`, unit-tested in `tests/test_selfhost_init.py`).
+Both are read. For example, a folder holding `pizza.owl` **and** a `sources.txt` with
+`bfo http://purl.obolibrary.org/obo/bfo.owl` loads **both** — pizza from the file and
+bfo from the URL:
+
+```
+my-ontologies/
+  pizza.owl          # a local file
+  sources.txt        # lists URLs to fetch (one is: bfo  http://purl.obolibrary.org/obo/bfo.owl)
+```
+
+**Advanced, instead of the above:** drop an `ontologies.config.json` — a list of
+`{"id", "path" | "url", "reasoner"}` for per-ontology control. When present it is
+**authoritative and replaces** the files/`sources.txt` scan.
+
+The `ontology-prepare` step turns whatever it finds into a single canonical
+`ontologies.json` that the worker loads (`deploy/selfhost_init.py`, unit-tested in
+`tests/test_selfhost_init.py`).
 
 ## UX
 ```bash

--- a/examples/selfhost/README.md
+++ b/examples/selfhost/README.md
@@ -24,17 +24,28 @@ Point `ONTOLOGIES_DIR` at your own folder:
 ONTOLOGIES_DIR=./my-ontologies docker compose -f deploy/docker-compose.selfhost.yml up
 ```
 
-That folder can contain, in increasing order of control:
+You feed ontologies to that folder in two ways that **work together in the same
+folder** — you don't pick one:
 
-1. **Bare files** — drop `myont.owl` in; its id becomes `myont`, reasoner ELK.
-2. **Web sources** — add a `sources.txt` (see `ontologies/sources.txt.example`)
-   listing URLs to download on startup.
-3. **Full control** — add an `ontologies.config.json`:
-   ```json
-   [
-     {"id": "myont", "path": "myont.owl", "reasoner": "elk"},
-     {"id": "go",    "url": "http://purl.obolibrary.org/obo/go.owl"}
-   ]
-   ```
+- **Files** — drop `.owl` files in directly (id from the filename, reasoner ELK).
+- **URLs** — add a `sources.txt` (see `ontologies/sources.txt.example`) listing
+  URLs to download on startup.
+
+Both are loaded. For example, this folder loads **both** pizza (file) and bfo (URL):
+
+```
+my-ontologies/
+  pizza.owl          # a local file
+  sources.txt        # one line:  bfo  http://purl.obolibrary.org/obo/bfo.owl
+```
+
+**Advanced, instead of the above** — for per-ontology control, add an
+`ontologies.config.json` (authoritative; it replaces the files/`sources.txt` scan):
+```json
+[
+  {"id": "myont", "path": "myont.owl", "reasoner": "elk"},
+  {"id": "go",    "url": "http://purl.obolibrary.org/obo/go.owl"}
+]
+```
 
 See [`deploy/SELF_HOSTING.md`](../../deploy/SELF_HOSTING.md) for details.


### PR DESCRIPTION
Closes #70

The self-hosting docs listed files / URLs / `ontologies.config.json` as three "modes", which reads as either/or. A user asked how to provide files **and** a `sources.txt` at the same time.

Clarifies that **files and `sources.txt` work together in the same folder** (both are loaded; `ontologies.config.json` is the authoritative alternative that replaces them), with a concrete combined example — pizza from a file + bfo from a URL in one folder — added to `README.md`, `deploy/SELF_HOSTING.md`, and `examples/selfhost/README.md`.

Docs only. The example matches the mixed file+URL run verified on 2026-07-21.