### PR TITLE
Cap hppcrt iterator pool size in worker JVMs

### DIFF
--- a/aberowlapi/server_manager.py
+++ b/aberowlapi/server_manager.py
@@ -134,6 +134,17 @@ class OntologyServerManager:
         env = os.environ.copy()
         # Ensure JAVA_OPTS are set, provide smaller default if needed for testing
         env['JAVA_OPTS'] = os.getenv('JAVA_OPTS', '-Xmx2g -Xms512m')
+
+        # OWLAPI's HPPCSet wraps hppcrt's ObjectHashSet, and every such set
+        # pre-allocates an IteratorPool. When HPPC_ITERATOR_POOLSIZE is unset,
+        # hppcrt sizes that pool to the CPU count, so the cost per set scales
+        # with the host's cores rather than with the ontology. On a 256-core
+        # host this measured 80% of a worker's live heap (1.77e9 pooled
+        # iterators = 155 GB of 191 GB on the NCBITaxon worker).
+        if 'HPPC_ITERATOR_POOLSIZE' not in env['JAVA_OPTS']:
+            pool_size = os.getenv('HPPC_ITERATOR_POOLSIZE', '4')
+            env['JAVA_OPTS'] += f' -DHPPC_ITERATOR_POOLSIZE={pool_size}'
+
         logging.info(f"Using JAVA_OPTS: {env['JAVA_OPTS']}")
 
         # Command arguments - Added '-d' for debug output


### PR DESCRIPTION
Closes #74.

## What

One-line behavioural change in `aberowlapi/server_manager.py`: append `-DHPPC_ITERATOR_POOLSIZE=4` to `JAVA_OPTS` unless the operator already set it.

This is the single point every worker launch path goes through (`docker/scripts/api_server.py` -> `OntologyServerManager.run()`), so it covers the compose stacks, `deploy/launch_workers.py`, and `scripts/rebuild_lbucket.py` without touching each one.

## Why

`hppcrt`'s `IteratorPool` sizes itself to `availableProcessors` when the property is unset, and OWLAPI allocates one such pool per `HPPCSet`. Worker heap therefore scales with the host's core count rather than with the ontology. On beta's 256-core host this was **81% of the live heap** (1.77e9 pooled iterators, 155 GB of 191 GB on the NCBITaxon worker). Full evidence, including the decompiled `IteratorPool.<clinit>`, is in #74.

## Measurement

Same config file as `worker_15` (chebi only), same image, same mounts, only the flag differs:

| configuration | live heap (post-GC) |
|---|---:|
| default (pool = 256) | 10.80 GB |
| `-DHPPC_ITERATOR_POOLSIZE=4` | **2.44 GB** |

Three DL `subeq` queries returned identical result counts against both workers (100000 / 7 / 100000), so answers are unchanged.

## Risk

Low, and reversible by setting the env var.

- `MAX_SIZE` is `4 * INITIAL_SIZE`, and `borrow()` on an exhausted pool allocates a fresh iterator instead of failing. The setting trades pooled reuse for allocation churn; it cannot change results.
- Respects an existing `HPPC_ITERATOR_POOLSIZE` in `JAVA_OPTS`, and is tunable per deployment via the `HPPC_ITERATOR_POOLSIZE` env var.
- Takes effect on worker restart only.

Benefit is core-count dependent: ~77% on the 256-core beta host, ~20% on the 16-core production workers, where pools are already only 16 deep.

## Suggested validation before prod

Restart one beta worker with the flag and confirm the fleet RSS drop and unchanged query results, then roll production workers one at a time.