### PR TITLE
Make worker status polling bounded, resilient, and triggerable

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -70,6 +70,11 @@ UPDATE_CHECK_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL_SECONDS", "86400"))
 # schedule; otherwise trigger them on demand via /admin/sync_sources and
 # /admin/check_updates.
 ENABLE_AUTO_SYNC = os.getenv("ENABLE_AUTO_SYNC", "false").lower() in ("1", "true", "yes")
+# Worker status polling. The sweep used to run unbounded over every registered
+# ontology, which made browsing slow and eventually exhausted the Redis pool.
+# Interval 0 disables the sweep; refresh explicitly via POST /admin/refresh_status.
+STATUS_POLL_INTERVAL = int(os.getenv("STATUS_POLL_INTERVAL", "300"))
+STATUS_POLL_CONCURRENCY = max(1, int(os.getenv("STATUS_POLL_CONCURRENCY", "16")))
 ONTOLOGIES_BASE_PATH = os.getenv("ONTOLOGIES_HOST_PATH", "/data/ontologies")
 ABEROWL_REPO_PATH = os.getenv("ABEROWL_REPO_PATH", "/opt/aberowl")
 
@@ -308,8 +313,15 @@ async def _load_servers_from_file():
         logger.error(f"Failed to load servers from file: {e}")
 
 
-async def fetch_and_update_server_metadata(server: Dict[str, Any]):
-    """Fetches metadata for a single server and updates Redis."""
+async def fetch_and_update_server_metadata(
+    server: Dict[str, Any],
+    session: Optional[aiohttp.ClientSession] = None,
+):
+    """Fetches metadata for a single server and updates Redis.
+
+    Pass `session` to reuse one connection pool across a sweep; without it a
+    private session is created (fine for the single-server registration path).
+    """
     url = server.get("url")
     ontology = server.get("ontology")
     if not url or not ontology:
@@ -326,24 +338,29 @@ async def fetch_and_update_server_metadata(server: Dict[str, Any]):
     # Pass ontologyId so multi-ontology workers return per-ontology metadata with title
     stats_url = f"{poll_base.rstrip('/')}/api/getStatistics.groovy?ontologyId={ontology}"
 
-    logger.info(f"Fetching metadata for {ontology} from {stats_url} (originally {url})")
+    logger.debug(f"Fetching metadata for {ontology} from {stats_url} (originally {url})")
+    owned_session = session is None
+    if owned_session:
+        session = aiohttp.ClientSession()
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(stats_url, timeout=30) as response:
-                if response.status == 200:
-                    stats = await response.json()
-                    server.update(stats)
-                    server["status"] = "online"
-                    # Backfill any fields the OWL file didn't carry (title,
-                    # description, homepage, license, contact) from OBO Foundry.
-                    _apply_registry_fallbacks(server)
-                    logger.info(f"Successfully updated metadata for {ontology} (title: {server.get('title', '')})")
-                else:
-                    logger.warning(f"Failed to fetch metadata for {ontology}. Status: {response.status}")
-                    server["status"] = "offline"
+        async with session.get(stats_url, timeout=30) as response:
+            if response.status == 200:
+                stats = await response.json()
+                server.update(stats)
+                server["status"] = "online"
+                # Backfill any fields the OWL file didn't carry (title,
+                # description, homepage, license, contact) from OBO Foundry.
+                _apply_registry_fallbacks(server)
+                logger.debug(f"Successfully updated metadata for {ontology} (title: {server.get('title', '')})")
+            else:
+                logger.warning(f"Failed to fetch metadata for {ontology}. Status: {response.status}")
+                server["status"] = "offline"
     except Exception as e:
         logger.error(f"Error fetching metadata for {ontology}: {e}")
         server["status"] = "offline"
+    finally:
+        if owned_session:
+            await session.close()
 
     # Always apply registry fallbacks for any still-empty fields (e.g. when the
     # worker was unreachable above, title can still come from the cache).
@@ -563,35 +580,91 @@ def _apply_registry_fallbacks(server: Dict[str, Any]):
             server[field] = meta[field]
 
 
-async def _fetch_and_update_all_servers():
-    """Helper to fetch metadata for all servers in Redis."""
-    logger.info("Starting metadata fetch for all registered servers.")
-    server_keys = await redis_client.hkeys("registered_servers")
-    if not server_keys:
-        logger.info("No registered servers to fetch metadata for.")
-        return
+async def _fetch_and_update_all_servers(only: Optional[List[str]] = None):
+    """Refresh worker-reported metadata/status for registered ontologies.
 
-    tasks = []
-    for key in server_keys:
-        server_json = await redis_client.hget("registered_servers", key)
-        if server_json:
-            server = json.loads(server_json)
-            tasks.append(fetch_and_update_server_metadata(server))
-    
-    if tasks:
-        await asyncio.gather(*tasks)
+    Concurrency is bounded by STATUS_POLL_CONCURRENCY. Previously every
+    registered ontology was polled at once via a bare `asyncio.gather`; with
+    462 ontologies that opened 462 aiohttp sessions and issued 462 concurrent
+    Redis writes, which exhausted the Redis pool and killed this coroutine with
+    `MaxConnectionsError` (production, 2026-07-20). It was also the source of
+    the periodic browsing slowdown.
+
+    Pass `only` to refresh a subset — e.g. just the ontologies on a worker that
+    was restarted during a deploy.
+    """
+    label = f"{len(only)} requested" if only else "all registered"
+    logger.info(f"Starting metadata fetch for {label} servers.")
+
+    # One HGETALL instead of HKEYS + one HGET per ontology.
+    entries = await redis_client.hgetall("registered_servers")
+    if not entries:
+        logger.info("No registered servers to fetch metadata for.")
+        return 0
+
+    wanted = set(only) if only else None
+    servers = []
+    for key, server_json in entries.items():
+        if wanted is not None and key not in wanted:
+            continue
+        try:
+            servers.append(json.loads(server_json))
+        except (TypeError, ValueError):
+            logger.warning(f"Skipping unparseable registry entry for {key}")
+
+    if not servers:
+        logger.info("No matching registered servers to fetch metadata for.")
+        return 0
+
+    sem = asyncio.Semaphore(STATUS_POLL_CONCURRENCY)
+
+    async def _one(server, session):
+        async with sem:
+            await fetch_and_update_server_metadata(server, session=session)
+
+    connector = aiohttp.TCPConnector(limit=STATUS_POLL_CONCURRENCY)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        # return_exceptions so one bad worker cannot abort the whole sweep.
+        results = await asyncio.gather(
+            *(_one(s, session) for s in servers), return_exceptions=True
+        )
+
+    failed = [r for r in results if isinstance(r, Exception)]
+    if failed:
+        logger.warning(
+            f"Metadata fetch: {len(failed)}/{len(servers)} raised; first: {failed[0]!r}"
+        )
+
     # Persist the registry to the backup file ONCE per cycle, not once per
     # server: the per-server write was O(n^2) and blocked the event loop
     # (synchronous full-list json.dump), causing intermittent query stalls.
     await _write_servers_to_file()
-    logger.info("Finished metadata fetch for all registered servers.")
+    logger.info(f"Finished metadata fetch for {len(servers)} servers.")
+    return len(servers)
 
 
 async def periodic_metadata_fetch_task():
-    """Periodically fetches metadata for all registered servers."""
+    """Periodically refresh worker status.
+
+    Set STATUS_POLL_INTERVAL=0 to disable the sweep entirely and rely on
+    POST /admin/refresh_status instead. Any failure is logged and the loop
+    continues; previously an exception escaped here and killed the task
+    permanently, freezing every ontology's status at its last polled value.
+    """
+    if STATUS_POLL_INTERVAL <= 0:
+        logger.info(
+            "Periodic status polling disabled (STATUS_POLL_INTERVAL=0); "
+            "use POST /admin/refresh_status to refresh on demand."
+        )
+        return
     while True:
-        await asyncio.sleep(60)
-        await _fetch_and_update_all_servers()
+        await asyncio.sleep(STATUS_POLL_INTERVAL)
+        try:
+            await _fetch_and_update_all_servers()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Periodic metadata fetch failed; continuing.")
 
 
 async def _migrate_unify_registries() -> None:
@@ -2498,6 +2571,32 @@ async def admin_sync_sources(
     """
     asyncio.create_task(_sync_sources_once())
     return {"status": "source_sync_triggered"}
+
+
+@app.post("/admin/refresh_status")
+async def admin_refresh_status(
+    ontologies: Optional[str] = None,
+    wait: bool = True,
+    credentials: HTTPBasicCredentials = Depends(_require_admin),
+):
+    """Re-poll workers and refresh ontology status on demand.
+
+    This is the deploy hook: after restarting a worker, refresh just its
+    ontologies instead of waiting for (or relying on) the periodic sweep.
+
+    - `ontologies`: comma-separated ids to refresh. Omit to refresh everything.
+    - `wait`: when true (default) the refresh completes before responding, so
+      the caller can read back an accurate status immediately. Pass false to
+      run it in the background.
+
+    Cheap and safe to call repeatedly; it only re-reads worker metadata.
+    """
+    only = [o.strip() for o in ontologies.split(",") if o.strip()] if ontologies else None
+    if not wait:
+        asyncio.create_task(_fetch_and_update_all_servers(only))
+        return {"status": "refresh_triggered", "requested": only or "all"}
+    refreshed = await _fetch_and_update_all_servers(only)
+    return {"status": "refreshed", "count": refreshed, "requested": only or "all"}
 
 
 @app.post("/admin/check_updates")

--- a/tests/test_status_poller.py
+++ b/tests/test_status_poller.py
@@ -1,0 +1,157 @@
+"""Tests for worker status polling.
+
+Regression cover for the production incident on 2026-07-20: the sweep polled
+every registered ontology at once, which exhausted the Redis connection pool and
+raised MaxConnectionsError out of `periodic_metadata_fetch_task`. Because the
+`while True` loop had no exception guard, the task died permanently and every
+ontology's status froze at its last polled value for two weeks.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO / "central_server"))
+
+
+class FakeRedis:
+    """Async Redis mock covering only what the poller uses."""
+
+    def __init__(self, entries=None):
+        self._data = {"registered_servers": dict(entries or {})}
+
+    async def hgetall(self, name):
+        return dict(self._data.get(name, {}))
+
+    async def hset(self, name, key, value):
+        self._data.setdefault(name, {})[key] = value
+
+    async def hget(self, name, key):
+        return self._data.get(name, {}).get(key)
+
+
+def _entries(n, prefix="ont"):
+    return {
+        f"{prefix}{i}": json.dumps(
+            {"ontology": f"{prefix}{i}", "ontology_id": f"{prefix}{i}",
+             "url": f"http://worker-{i}:8080/", "status": "offline"}
+        )
+        for i in range(n)
+    }
+
+
+@pytest.fixture
+def main_module():
+    import app.main as m
+    return m
+
+
+def test_sweep_respects_concurrency_limit(main_module):
+    """The sweep must never exceed STATUS_POLL_CONCURRENCY in flight.
+
+    This is the property whose absence exhausted the Redis pool in production.
+    """
+    fake = FakeRedis(_entries(50))
+    in_flight = 0
+    peak = 0
+
+    async def fake_fetch(server, session=None):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+
+    with patch.object(main_module, "redis_client", fake), \
+         patch.object(main_module, "STATUS_POLL_CONCURRENCY", 5), \
+         patch.object(main_module, "fetch_and_update_server_metadata", fake_fetch), \
+         patch.object(main_module, "_write_servers_to_file", AsyncMock()):
+        count = asyncio.run(main_module._fetch_and_update_all_servers())
+
+    assert count == 50
+    assert peak <= 5, f"peak concurrency {peak} exceeded the limit of 5"
+
+
+def test_sweep_can_refresh_a_subset(main_module):
+    """`only` refreshes just the named ontologies — the deploy hook."""
+    fake = FakeRedis(_entries(20))
+    polled = []
+
+    async def fake_fetch(server, session=None):
+        polled.append(server["ontology"])
+
+    with patch.object(main_module, "redis_client", fake), \
+         patch.object(main_module, "fetch_and_update_server_metadata", fake_fetch), \
+         patch.object(main_module, "_write_servers_to_file", AsyncMock()):
+        count = asyncio.run(
+            main_module._fetch_and_update_all_servers(["ont3", "ont7"])
+        )
+
+    assert count == 2
+    assert sorted(polled) == ["ont3", "ont7"]
+
+
+def test_one_failing_worker_does_not_abort_the_sweep(main_module):
+    """A single bad worker must not prevent the others being refreshed."""
+    fake = FakeRedis(_entries(10))
+    polled = []
+
+    async def fake_fetch(server, session=None):
+        if server["ontology"] == "ont4":
+            raise RuntimeError("worker exploded")
+        polled.append(server["ontology"])
+
+    with patch.object(main_module, "redis_client", fake), \
+         patch.object(main_module, "fetch_and_update_server_metadata", fake_fetch), \
+         patch.object(main_module, "_write_servers_to_file", AsyncMock()):
+        count = asyncio.run(main_module._fetch_and_update_all_servers())
+
+    assert count == 10
+    assert len(polled) == 9 and "ont4" not in polled
+
+
+def test_periodic_task_survives_a_failing_sweep(main_module):
+    """The loop must keep running after a sweep raises.
+
+    Previously the exception escaped and killed the task for good.
+    """
+    calls = []
+
+    async def flaky():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("MaxConnectionsError-alike")
+
+    async def drive():
+        with patch.object(main_module, "STATUS_POLL_INTERVAL", 0.01), \
+             patch.object(main_module, "_fetch_and_update_all_servers", flaky):
+            task = asyncio.create_task(main_module.periodic_metadata_fetch_task())
+            await asyncio.sleep(0.15)
+            still_running = not task.done()
+            task.cancel()
+            return still_running
+
+    still_running = asyncio.run(drive())
+    assert len(calls) >= 2, "loop stopped after the first failure"
+    assert still_running, "task died instead of continuing"
+
+
+def test_polling_can_be_disabled(main_module):
+    """STATUS_POLL_INTERVAL=0 disables the sweep entirely."""
+    called = []
+
+    async def should_not_run():
+        called.append(1)
+
+    async def drive():
+        with patch.object(main_module, "STATUS_POLL_INTERVAL", 0), \
+             patch.object(main_module, "_fetch_and_update_all_servers", should_not_run):
+            await asyncio.wait_for(main_module.periodic_metadata_fetch_task(), timeout=1)
+
+    asyncio.run(drive())
+    assert called == []


### PR DESCRIPTION
Found while rolling #75 to production: worker-12 was restarted and came back healthy with 14 classified ontologies, but the public registry kept reporting them offline. The status poller had been dead for two weeks.

## What happened in production

```
Task exception was never retrieved
coro=<periodic_metadata_fetch_task()> exception=network:MaxConnectionsError
  File "app/main.py", line 582, in _fetch_and_update_all_servers
    await asyncio.gather(*tasks)
  File "app/main.py", line 353, in fetch_and_update_server_metadata
    await redis_client.hset("registered_servers", ontology, ...)
```

`_fetch_and_update_all_servers` polled **every** registered ontology at once through a bare `asyncio.gather`. At 462 ontologies that is 462 aiohttp sessions and 462 concurrent Redis writes, every 60 seconds. That exhausted the Redis connection pool on **2026-07-20 14:41:34**; the exception escaped the `while True` loop, which had no guard, so the task died for good.

Consequences, both confirmed on the live service:

- Every ontology's status froze at its last polled value. The `368 online / 94 offline` figure the site reports is a two-week-old snapshot, and at least 14 entries are now wrong.
- The same unbounded sweep is the periodic browsing slowdown — 462 concurrent worker fetches plus 462 Redis writes a minute, and 462 info log lines with it.

## Changes

- **Bounded concurrency.** A semaphore (`STATUS_POLL_CONCURRENCY`, default 16) plus one shared `aiohttp` session with a matching connector limit, instead of a session per ontology.
- **Failure isolation.** `gather(return_exceptions=True)`, so one unreachable worker no longer aborts the sweep for everyone else.
- **The loop cannot die.** A failed sweep is logged and retried on the next tick.
- **One `HGETALL`** instead of `HKEYS` plus a `HGET` per ontology.
- **Configurable cadence.** `STATUS_POLL_INTERVAL` (default 300s, previously a hardcoded 60). Set it to `0` to disable the sweep entirely and drive refreshes explicitly.
- **`POST /admin/refresh_status`** — refresh on demand, optionally for a subset:

  ```
  POST /admin/refresh_status?ontologies=doid,pato,foodon
  POST /admin/refresh_status                 # everything
  ```

  Defaults to `wait=true` so the caller can read back an accurate status immediately. This is the deploy hook: after restarting a worker, refresh just that worker's ontologies.
- Per-ontology fetch logging demoted to `debug`.

## Tests

`tests/test_status_poller.py` covers the concurrency bound, subset refresh, failure isolation, loop survival after a failing sweep, and the disable switch. **All five fail against the unfixed code** and pass here.

Full suite: 72 passed, 1 failed — that failure (`test_sparql_plain_query`, a missing `execute_sparql` attribute) is pre-existing and reproduces identically on `main`.

## Deployment note

Because the running central server still has the dead task, this needs a central restart to take effect. `DEPLOY_FOLLOWUPS.md` records that as safe — the Redis registry and the ES indices both survive. I'd verify on beta first.