### PR TITLE
Drop stale test asserting the central server executes SPARQL

### DIFF
--- a/tests/test_central_api.py
+++ b/tests/test_central_api.py
@@ -285,20 +285,12 @@ class TestSparqlEndpoint:
         r = await client.get("/api/sparql")
         assert r.status_code == 400
 
-    @pytest.mark.asyncio
-    async def test_sparql_plain_query(self, client, test_app):
-        """Plain SPARQL (no OWL patterns) should pass through."""
-        with patch("app.main.execute_sparql", new_callable=AsyncMock, return_value={
-            "head": {"vars": ["s"]},
-            "results": {"bindings": [{"s": {"type": "uri", "value": "http://example.org/A"}}]},
-        }):
-            r = await client.get("/api/sparql", params={
-                "query": "SELECT ?s WHERE { ?s a <http://www.w3.org/2002/07/owl#Class> } LIMIT 1"
-            })
-            assert r.status_code == 200
-            body = r.json()
-            assert "results" in body
-            assert body.get("expansions") is None  # No expansions for plain SPARQL
+    # NOTE: there is deliberately no test here for executing a plain SPARQL
+    # query. AberOWL rewrites SPARQL, it never executes it — /api/sparql returns
+    # {rewritten_query, expansions, errors} and the caller runs the result
+    # against whatever endpoint they choose. Passthrough of a query carrying no
+    # OWL frames is covered in tests/test_sparql_expander.py
+    # (test_no_match_on_plain_sparql, test_no_frames_returns_query_unchanged).
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Noticed while running the suite for #77: `tests/test_central_api.py::TestSparqlEndpoint::test_sparql_plain_query` fails on `main`.

```
AttributeError: <module 'app.main'> does not have the attribute 'execute_sparql'
```

## Why it is wrong, not just broken

The test patches `app.main.execute_sparql`. No such function exists — the only `_execute_sparql` in the tree lives in `central_server/mcp_ontology_server.py`. And it should not exist: **AberOWL rewrites SPARQL, it never executes it.** `CLAUDE.md` states "the central server does not store triples and does not execute SPARQL", and `/api/sparql` returns:

```json
{"rewritten_query": "...", "expansions": [...], "errors": [...]}
```

The caller sends `rewritten_query` to whatever endpoint they choose. So the test's assertions (`"results" in body`, `expansions is None`) describe a response shape the endpoint cannot produce. It was written against a design the project deliberately does not have.

Since it failed rather than passing spuriously, it was contributing no signal — just noise on every run.

## Coverage

None lost. Passthrough of a query carrying no OWL frames is already covered in `tests/test_sparql_expander.py` by `test_no_match_on_plain_sparql` and `test_no_frames_returns_query_unchanged`. I left a comment where the test was so it does not get reintroduced.

After this, `test_central_api.py`, `test_sparql_expander.py` and `test_mcp_servers.py` are green: **67 passed**.

Independent of #77 — no overlapping files.