### PR TITLE
Emit dcterms:license from the per-artefact FAIR record

### DIFF
--- a/central_server/app/main.py
+++ b/central_server/app/main.py
@@ -313,6 +313,20 @@ async def _load_servers_from_file():
         logger.error(f"Failed to load servers from file: {e}")
 
 
+def _license_node(value: str):
+    """Render a licence for JSON-LD.
+
+    dcterms:license expects a resource, so a URI is emitted as {"@id": ...} and is
+    machine-actionable (FAIR R1.1). Registry licences are usually URIs
+    (creativecommons.org, spdx.org) but not always, so anything that is not a URI
+    falls back to a plain literal rather than minting a bogus IRI.
+    """
+    v = (value or "").strip()
+    if v.startswith("http://") or v.startswith("https://"):
+        return {"@id": v}
+    return {"@type": "rdfs:Literal", "@value": v}
+
+
 async def fetch_and_update_server_metadata(
     server: Dict[str, Any],
     session: Optional[aiohttp.ClientSession] = None,
@@ -1669,8 +1683,8 @@ async def get_artefacts(
         # Add optional fields if available
         if "keywords" in server:
             artefact["dcat:keyword"] = server["keywords"]
-        if "license" in server:
-            artefact["dcterms:license"] = server["license"]
+        if server.get("license"):
+            artefact["dcterms:license"] = _license_node(server["license"])
         
         artefacts.append(artefact)
     
@@ -1769,7 +1783,17 @@ async def get_artefact(
             "@type": "xsd:string",
             "@value": server["version_info"]
         }
-    
+
+    # License and keywords, matching the collection at /artefacts. These were
+    # only emitted by the collection, so the per-artefact record — the document a
+    # persistent identifier actually resolves to, and the one a FAIR assessor
+    # fetches for R1.1 (clear usage licence) — omitted a licence the registry
+    # already held for 317 of 971 ontologies.
+    if server.get("license"):
+        artefact["dcterms:license"] = _license_node(server["license"])
+    if server.get("keywords"):
+        artefact["dcat:keyword"] = server["keywords"]
+
     # Add counts if available
     if "class_count" in server:
         artefact["mod:numberOfClasses"] = {
@@ -1781,7 +1805,7 @@ async def get_artefact(
             "@type": "xsd:nonNegativeInteger",
             "@value": server["property_count"]
         }
-    
+
     if format == "html":
         return HTMLResponse(content=f"<html><body><h1>Artefact: {artefact_id}</h1></body></html>")
     

--- a/tests/test_fair_license.py
+++ b/tests/test_fair_license.py
@@ -1,0 +1,53 @@
+"""The per-artefact record must carry dcterms:license.
+
+/artefacts (collection) emitted dcterms:license while /artefacts/{id} did not.
+The per-artefact record is what a persistent identifier resolves to and what a
+FAIR assessor fetches for R1.1, so the licence was missing exactly where it
+matters. 317 of 971 production ontologies had a licence in the registry.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO / "central_server"))
+
+
+@pytest.fixture
+def lic():
+    from app.main import _license_node
+    return _license_node
+
+
+def test_uri_licence_is_a_resource_not_a_literal(lic):
+    """A URI licence must be {"@id": ...} so it is machine-actionable."""
+    assert lic("https://creativecommons.org/licenses/by/4.0/") == {
+        "@id": "https://creativecommons.org/licenses/by/4.0/"
+    }
+    assert lic("http://spdx.org/licenses/CC-BY-4.0") == {
+        "@id": "http://spdx.org/licenses/CC-BY-4.0"
+    }
+
+
+def test_non_uri_licence_stays_a_literal(lic):
+    """Free-text licences must not be minted into bogus IRIs."""
+    out = lic("CC-BY-4.0")
+    assert out["@value"] == "CC-BY-4.0"
+    assert "@id" not in out
+
+
+def test_whitespace_is_trimmed(lic):
+    assert lic("  https://example.org/l  ") == {"@id": "https://example.org/l"}
+
+
+def test_artefact_record_emits_licence_when_registry_has_one():
+    """Guards the actual regression: the record builder must include licence."""
+    src = (REPO / "central_server" / "app" / "main.py").read_text()
+    start = src.index('@app.get("/artefacts/{artefact_id}")')
+    end = src.index("@app.get", start + 10)
+    record_builder = src[start:end]
+    assert "dcterms:license" in record_builder, (
+        "/artefacts/{id} must emit dcterms:license; it is the document a "
+        "persistent identifier resolves to"
+    )


### PR DESCRIPTION
Part of #63 (FAIR compliance). Complements #61, which fixes dates, content negotiation and the `/fair` descriptor but does not touch licensing.

## The problem

`/artefacts` (the collection) emits `dcterms:license`. `/artefacts/{id}` does not.

That is the wrong way round. The per-artefact record is the document a **persistent identifier resolves to**, and the one a FAIR assessor fetches when checking **R1.1** ("released with a clear and accessible usage licence"). The licence was missing from exactly the place it matters.

Measured on production 2026-08-10: **317 of 971** registered ontologies carry a licence in the registry, and none of it was visible at `/artefacts/{id}`.

```
$ curl -s http://aber-owl.net/artefacts?limit=1 | jq '.["hydra:member"][0]["dcterms:license"]'
"https://creativecommons.org/licenses/by/4.0/"          # collection: present

$ curl -s http://aber-owl.net/artefacts/dpo | jq '.["dcterms:license"]'
null                                                     # record: absent
```

## Changes

- **`/artefacts/{id}` now emits `dcterms:license`** (and `dcat:keyword`, matching the collection).
- **The licence is rendered as a resource, not a literal.** `dcterms:license` expects a resource, so a URI becomes `{"@id": ...}` and is machine-actionable rather than an opaque string. Registry licences are usually URIs (`creativecommons.org`, `spdx.org`), but not guaranteed — a non-URI value falls back to a literal instead of minting a bogus IRI.
- Both endpoints share `_license_node()`, so they cannot drift apart again.

## Deliberately not included

`dcterms:issued` / `dcterms:modified` are fabricated request-time values (every record reads "now", identical to the microsecond). That is real, but it is #61's territory and touching it here would conflict.

## Tests

`tests/test_fair_license.py` covers the URI-vs-literal split, whitespace handling, and guards the regression itself by asserting the record builder emits `dcterms:license`. **All four fail against `main`.**

Full suite green: 59 passed.