### PR TITLE
Pin mcp below 2.0 — 2.0 removed mcp.server.fastmcp

### DIFF
--- a/central_server/requirements.txt
+++ b/central_server/requirements.txt
@@ -1,11 +1,21 @@
-fastapi
-uvicorn[standard]
-jinja2
-aiohttp
-python-multipart
-redis
-pyyaml
-aiofiles
-mcp
-slowapi
-rdflib
+# NOTE: these were all unpinned, which broke production on 2026-08-10: a rebuild
+# pulled mcp 2.0.0, which moved `mcp.server.fastmcp`, and the MCP server failed to
+# start (nginx returned 502). Only `mcp` is constrained here because that is the
+# break we have evidence for; the versions in the comments are what the working
+# container had at the time, recorded so a future pinning pass has a known-good set.
+
+fastapi                 # working: 0.141.1
+uvicorn[standard]       # working: 0.52.1
+jinja2                  # working: 3.1.6
+aiohttp                 # working: 3.14.3
+python-multipart        # working: 0.0.32
+redis                   # working: 8.1.0
+pyyaml                  # working: 6.0.3
+aiofiles                # working: 25.1.0
+
+# mcp 2.0 removed mcp.server.fastmcp, which mcp_ontology_server.py imports.
+# 1.28.1 is verified working (it is what the pre-2026-08-10 image shipped).
+mcp>=1.28.1,<2.0
+
+slowapi                 # working: 0.1.10
+rdflib                  # working: 7.6.0


### PR DESCRIPTION
**Production incident, MCP currently returning 502.**

## What happened

Every dependency in `central_server/requirements.txt` was unpinned. Rebuilding the central image today resolved `mcp` to **2.0.0**, which no longer exposes `mcp.server.fastmcp`:

```
File "/code/mcp_ontology_server.py", line 33, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

The MCP server failed to start and nginx returns **502** for `/mcp/ontology/mcp`. No application code changed — this came entirely from an unpinned upgrade, so **any** rebuild would have triggered it. It was latent, not caused by the FAIR work that happened to prompt the rebuild.

## The fix

`mcp>=1.28.1,<2.0`. Version 1.28.1 is verified working — it is what the pre-2026-08-10 image shipped, and `from mcp.server.fastmcp import FastMCP` succeeds there (confirmed by running the old image directly).

## Why only `mcp`

All eleven dependencies are unpinned, and this is a real reproducibility problem — the same class of break can hit `fastapi`, `redis` or `aiohttp` on any future rebuild. But pinning the rest blindly would trade a known failure for an untested one. Instead, the versions from the currently-working container are recorded as comments:

```
fastapi 0.141.1 · uvicorn 0.52.1 · jinja2 3.1.6 · aiohttp 3.14.3
python-multipart 0.0.32 · redis 8.1.0 · pyyaml 6.0.3 · aiofiles 25.1.0
slowapi 0.1.10 · rdflib 7.6.0
```

That gives a known-good starting set for a proper pinning pass, which deserves its own PR and a test cycle.

## Note on `mcp` 2.0

Moving to 2.x is worth doing eventually, but it is an API migration in `mcp_ontology_server.py`, not a version bump. Constraining to 1.x restores service now without rushing that.